### PR TITLE
Infer full dataset

### DIFF
--- a/code/llm/projects/dutch_real/infer_cfg_large.json
+++ b/code/llm/projects/dutch_real/infer_cfg_large.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "src/new_code/regular_hparams_large.txt",
-  "CHECKPOINT_PATH": "projects/dutch_real/models/2017/model-epoch=00-v1.ckpt",
-  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "CHECKPOINT_PATH": "projects/dutch_real/models/2017_large/model-epoch=01-step=34848-val_loss=0.00.ckpt",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/no_mlm_encoded_upto_2017.h5",
   "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_large.h5",
   "BATCH_SIZE": 512
 }

--- a/code/llm/projects/dutch_real/infer_cfg_large.json
+++ b/code/llm/projects/dutch_real/infer_cfg_large.json
@@ -2,5 +2,6 @@
   "HPARAMS_PATH": "src/new_code/regular_hparams_large.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017/model-epoch=00-v1.ckpt",
   "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
-  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_large.h5"
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_large.h5",
+  "BATCH_SIZE": 512
 }

--- a/code/llm/projects/dutch_real/infer_cfg_large.json
+++ b/code/llm/projects/dutch_real/infer_cfg_large.json
@@ -1,0 +1,6 @@
+{
+  "HPARAMS_PATH": "src/new_code/regular_hparams_large.txt",
+  "CHECKPOINT_PATH": "projects/dutch_real/models/2017/model-epoch=00-v1.ckpt",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_large.h5"
+}

--- a/code/llm/projects/dutch_real/infer_cfg_medium.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium.json
@@ -2,5 +2,6 @@
   "HPARAMS_PATH": "src/new_code/regular_hparams_medium.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium/model-epoch=02-step=46550-val_loss=0.00.ckpt",
   "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
-  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium.h5"
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium.h5",
+  "BATCH_SIZE": 1024
 }

--- a/code/llm/projects/dutch_real/infer_cfg_medium.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium.json
@@ -1,0 +1,6 @@
+{
+  "HPARAMS_PATH": "src/new_code/regular_hparams_medium.txt",
+  "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium/model-epoch=02-step=46550-val_loss=0.00.ckpt",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium.h5"
+}

--- a/code/llm/projects/dutch_real/infer_cfg_medium.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "src/new_code/regular_hparams_medium.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium/model-epoch=02-step=46550-val_loss=0.00.ckpt",
-  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/no_mlm_encoded_upto_2017.h5",
   "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium.h5",
   "BATCH_SIZE": 1024
 }

--- a/code/llm/projects/dutch_real/infer_cfg_medium2x.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium2x.json
@@ -2,5 +2,6 @@
   "HPARAMS_PATH": "src/new_code/regular_hparams_medium2x.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium2x/model-epoch=02-step=45570-val_loss=0.00.ckpt",
   "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
-  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium2x.h5"
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium2x.h5",
+  "BATCH_SIZE": 1024
 }

--- a/code/llm/projects/dutch_real/infer_cfg_medium2x.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium2x.json
@@ -1,0 +1,6 @@
+{
+  "HPARAMS_PATH": "src/new_code/regular_hparams_medium2x.txt",
+  "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium2x/model-epoch=02-step=45570-val_loss=0.00.ckpt",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium2x.h5"
+}

--- a/code/llm/projects/dutch_real/infer_cfg_medium2x.json
+++ b/code/llm/projects/dutch_real/infer_cfg_medium2x.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "src/new_code/regular_hparams_medium2x.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_medium2x/model-epoch=02-step=45570-val_loss=0.00.ckpt",
-  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/no_mlm_encoded_upto_2017.h5",
   "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_medium2x.h5",
   "BATCH_SIZE": 1024
 }

--- a/code/llm/projects/dutch_real/infer_cfg_small.json
+++ b/code/llm/projects/dutch_real/infer_cfg_small.json
@@ -1,0 +1,6 @@
+{
+  "HPARAMS_PATH": "src/new_code/regular_hparams_small.txt",
+  "CHECKPOINT_PATH": "projects/dutch_real/models/2017_small/model-epoch=03-step=27798-val_loss=0.00.ckpt",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_small.h5"
+}

--- a/code/llm/projects/dutch_real/infer_cfg_small.json
+++ b/code/llm/projects/dutch_real/infer_cfg_small.json
@@ -2,5 +2,6 @@
   "HPARAMS_PATH": "src/new_code/regular_hparams_small.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_small/model-epoch=03-step=27798-val_loss=0.00.ckpt",
   "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
-  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_small.h5"
+  "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_small.h5",
+  "BATCH_SIZE": 2048
 }

--- a/code/llm/projects/dutch_real/infer_cfg_small.json
+++ b/code/llm/projects/dutch_real/infer_cfg_small.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "src/new_code/regular_hparams_small.txt",
   "CHECKPOINT_PATH": "projects/dutch_real/models/2017_small/model-epoch=03-step=27798-val_loss=0.00.ckpt",
-  "TOKENIZED_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "TOKENIZED_PATH": "projects/dutch_real/gen_data/no_mlm_encoded_upto_2017.h5",
   "EMB_WRITE_PATH": "projects/dutch_real/gen_data/embeddings/2017_small.h5",
   "BATCH_SIZE": 2048
 }

--- a/code/llm/slurm_scripts/infer_large.sh
+++ b/code/llm/slurm_scripts/infer_large.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#SBATCH --job-name=infer_small
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=03:00:00
+#SBATCH --mem=80G
+#SBATCH -p comp_env
+#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
+#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+
+declare PREFIX="/gpfs/ostor/ossc9424/homedir/"
+
+export CUDA_VISIBLE_DEVICES=3
+
+echo "job started"
+
+module purge 
+module load 2022
+module load Python/3.10.4-GCCcore-11.3.0
+module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+module load SciPy-bundle/2022.05-foss-2022a
+module load matplotlib/3.5.2-foss-2022a
+
+source "$PREFIX"/ossc_new/bin/activate
+
+cd "$PREFIX"/Tanzir/LifeToVec_Nov/
+
+date
+time python -m src.new_code.infer_embedding projects/dutch_real/infer_cfg_large.json
+
+echo "job ended successfully"

--- a/code/llm/slurm_scripts/infer_medium.sh
+++ b/code/llm/slurm_scripts/infer_medium.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#SBATCH --job-name=infer_medium
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=03:00:00
+#SBATCH --mem=80G
+#SBATCH -p comp_env
+#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
+#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+
+declare PREFIX="/gpfs/ostor/ossc9424/homedir/"
+
+export CUDA_VISIBLE_DEVICES=1
+
+echo "job started"
+
+module purge 
+module load 2022
+module load Python/3.10.4-GCCcore-11.3.0
+module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+module load SciPy-bundle/2022.05-foss-2022a
+module load matplotlib/3.5.2-foss-2022a
+
+source "$PREFIX"/ossc_new/bin/activate
+
+cd "$PREFIX"/Tanzir/LifeToVec_Nov/
+
+date
+time python -m src.new_code.infer_embedding projects/dutch_real/infer_cfg_medium.json
+
+echo "job ended successfully"

--- a/code/llm/slurm_scripts/infer_medium2x.sh
+++ b/code/llm/slurm_scripts/infer_medium2x.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#SBATCH --job-name=infer_medium2x
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=03:00:00
+#SBATCH --mem=80G
+#SBATCH -p comp_env
+#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
+#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+
+declare PREFIX="/gpfs/ostor/ossc9424/homedir/"
+
+export CUDA_VISIBLE_DEVICES=2
+
+echo "job started"
+
+module purge 
+module load 2022
+module load Python/3.10.4-GCCcore-11.3.0
+module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+module load SciPy-bundle/2022.05-foss-2022a
+module load matplotlib/3.5.2-foss-2022a
+
+source "$PREFIX"/ossc_new/bin/activate
+
+cd "$PREFIX"/Tanzir/LifeToVec_Nov/
+
+date
+time python -m src.new_code.infer_embedding projects/dutch_real/infer_cfg_medium2x.json
+
+echo "job ended successfully"

--- a/code/llm/slurm_scripts/infer_small.sh
+++ b/code/llm/slurm_scripts/infer_small.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+#SBATCH --job-name=infer_small
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=03:00:00
+#SBATCH --mem=80G
+#SBATCH -p comp_env
+#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
+#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+
+declare PREFIX="/gpfs/ostor/ossc9424/homedir/"
+
+export CUDA_VISIBLE_DEVICES=0
+
+echo "job started"
+
+module purge 
+module load 2022
+module load Python/3.10.4-GCCcore-11.3.0
+module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+module load SciPy-bundle/2022.05-foss-2022a
+module load matplotlib/3.5.2-foss-2022a
+
+source "$PREFIX"/ossc_new/bin/activate
+
+cd "$PREFIX"/Tanzir/LifeToVec_Nov/
+
+date
+time python -m src.new_code.infer_embedding projects/dutch_real/infer_cfg_small.json
+
+echo "job ended successfully"

--- a/code/llm/src/new_code/infer_embedding.py
+++ b/code/llm/src/new_code/infer_embedding.py
@@ -42,6 +42,7 @@ def inference(cfg):
   tokenized_path = cfg['TOKENIZED_PATH']
   model = load_model(checkpoint_path, hparams)
 
+  logging.info("Reading from tokenzied path: %s", tokenized_path)
   dataset = CustomIterableDataset(
     tokenized_path, 
     validation=False,

--- a/code/llm/src/new_code/infer_embedding.py
+++ b/code/llm/src/new_code/infer_embedding.py
@@ -1,28 +1,18 @@
-import pandas as pd
 import numpy as np
-import src.transformer
+import torch
+import json
+import sys
+import logging 
+from tqdm import tqdm
+
 from src.transformer.models import TransformerEncoder
 from src.new_code.load_data import CustomIterableDataset
 from src.new_code.pretrain import read_hparams_from_file
+from src.new_code.pipeline import write_to_hdf5
 from src.new_code.utils import read_json, print_now
 from torch.utils.data import DataLoader
-import torch
-import json
-import pickle
-from torch.utils.data._utils.collate import default_collate
-import sys
-from tqdm import tqdm
 
-def custom_collate(batch):
-    collated_batch = {}
-    for key in batch[0].keys():
-        # Check if the key is 'sequence_id' and handle it separately
-        if key == 'sequence_id':
-            collated_batch[key] = [item[key] for item in batch]
-        else:
-            collated_batch[key] = default_collate([item[key] for item in batch])
 
-    return collated_batch
 
 def load_model(checkpoint_path, hparams):
   model = TransformerEncoder.load_from_checkpoint(checkpoint_path, hparams=hparams)
@@ -48,26 +38,16 @@ def inference(cfg):
   hparams_path = cfg['HPARAMS_PATH']
   hparams = read_hparams_from_file(hparams_path)
   checkpoint_path = cfg['CHECKPOINT_PATH']
-  cls_path = cfg['CLS_WRITE_PATH']
-  mean_path = cfg['MEAN_WRITE_PATH']
+  write_path = cfg['EMB_WRITE_PATH']
   tokenized_path = cfg['TOKENIZED_PATH']
   model = load_model(checkpoint_path, hparams)
 
   dataset = CustomIterableDataset(
     tokenized_path, 
     validation=False,
-    inference=False
+    inference=True
   )
   dataset.set_mlm_encoded(False)
-  # with open(tokenized_path, 'rb') as file:
-  #   dataset = pickle.load(file)
-  # dataset.set_mlm_encoded(False)
-  ## unclear from here
-  ## XXX won't work for now
-  # if "original_sequence" in dataset.data:
-  #   dataset.data["input_ids"][:, 0, :] = dataset.data["original_sequence"]
-  # print_now_dataset_stuff(dataset) 
-  ## unclear from here
 
   if 'BATCH_SIZE' in cfg:
     batch_size = cfg['BATCH_SIZE']
@@ -75,13 +55,7 @@ def inference(cfg):
     batch_size = 512
   dataloader = DataLoader(dataset, batch_size=batch_size)
 
-  all_outputs = []
-  people_embedding_cls = {}
-  people_embedding_mean = {}
-  for i, batch in enumerate(dataloader):
-  # for i in tqdm(range(0, len(dataset), batch_size)):
-      # Move the batch to GPU if available
-      # batch = dataset[i:i+batch_size]
+  for i, batch in enumerate(tqdm(dataloader, desc="Inferring by batch")):
       if torch.cuda.is_available():
           batch['input_ids'] = batch['input_ids'].to('cuda')
           batch['padding_mask'] = batch['padding_mask'].to('cuda')
@@ -95,34 +69,26 @@ def inference(cfg):
         print_now(f"printing for batch {i}:")
         print_now(f"len(outputs) = {len(outputs)}")
         print_now(f"batch length = {len(batch['sequence_id'])}")
+
+      sequence_id = [x.decode() for x in batch["sequence_id"]]
+      cls_emb = outputs[:, 0, :].cpu()
+      mean_emb = torch.mean(outputs, axis=1).cpu()
+      data_dict = {
+         "sequence_id": sequence_id,
+         "cls_emb": cls_emb,
+         "mean_emb": mean_emb
+      }
+
+      write_to_hdf5(write_path, data_dict, np.float16)
         
-      for j in range(len(batch['sequence_id'])):
-        # primary_id = str(batch['sequence_id'][j])
-        primary_id = batch['sequence_id'][j].decode()
-        cls_emb = outputs[j][0].cpu()
-        mean_emb = torch.mean(outputs[j],0).cpu()
-        people_embedding_cls[primary_id] = cls_emb.tolist()
-        people_embedding_mean[primary_id] = mean_emb.tolist()
-        if i%100 == 0 and j==0:
-          print_now(f"cls_emb dim = {cls_emb.shape}")
-          print_now(f"mean_emb dim = {mean_emb.shape}")
-          assert cls_emb.shape == mean_emb.shape          
-      # Append the outputs to the list
-      # all_outputs.append(outputs)  # Move back to CPU if necessary
-      # print_now(type(all_outputs[-1]))
-      # print_now(all_outputs[-1])
-
-  # Concatenate the outputs along the batch dimension
-  # all_outputs = torch.cat(all_outputs, dim=0)
-
-  # 'all_outputs' now contains the model's predictions or outputs for the entire dataset
-  # XXX this needs to be fixed and we should also use a hdf5 file -- what are the keys of the file
-    # and it should go into the loop above
-  dump_embeddings(cls_path, people_embedding_cls)
-  dump_embeddings(mean_path, people_embedding_mean)
 
 
 if __name__ == "__main__":
+  logging.basicConfig(
+    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+    level=logging.DEBUG
+  )
   CFG_PATH = sys.argv[1]
   print_now(CFG_PATH)
   cfg = read_json(CFG_PATH)

--- a/code/llm/src/new_code/load_data.py
+++ b/code/llm/src/new_code/load_data.py
@@ -13,8 +13,6 @@ class CustomIterableDataset(IterableDataset):
         self.validation = validation
         self.num_val_items = num_val_items
         self.val_split = val_split
-        if inference:
-            assert not mlm_encoded
         self.inference = inference
         self.set_mlm_encoded(mlm_encoded)
 

--- a/code/llm/src/new_code/pipeline.py
+++ b/code/llm/src/new_code/pipeline.py
@@ -197,7 +197,7 @@ def encode_documents(docs_with_counter, write_path_prefix, needed_ids, do_mlm, m
   write_path = f"{write_path_prefix}_{counter}.h5" 
   write_to_hdf5(write_path, data_dict)
 
-def init_hdf5_datasets(h5f, data_dict):
+def init_hdf5_datasets(h5f, data_dict, dtype='i4'):
   """Initialize HDF5 datasets when they do not exist."""
   for key in data_dict:
     if key == 'sequence_id':
@@ -228,7 +228,7 @@ def init_hdf5_datasets(h5f, data_dict):
         key, 
         shape=final_shape,
         maxshape=maxshape, 
-        dtype='i4', 
+        dtype=dtype, 
         chunks=chunks, 
         compression="gzip"
       )
@@ -249,13 +249,18 @@ def debug_log_hdf5(data_dict, h5f):
     else:
       logging.debug("%s, %s", key, val.shape)
 
-def write_to_hdf5(write_path, data_dict):
-  """Write processed data to an HDF5 file."""
+def write_to_hdf5(write_path, data_dict, dtype='i4'):
+  """Write processed data to an HDF5 file.
+
+  Args:
+  dtype: data types for arrays except the `sequence_id` array. 
+   
+  """
   if len(data_dict) == 0:
     return
   with h5py.File(write_path, 'a') as h5f:
     if 'sequence_id' not in h5f:
-      init_hdf5_datasets(h5f, data_dict)
+      init_hdf5_datasets(h5f, data_dict, dtype)
 
     current_size = h5f['sequence_id'].shape[0]
     new_size = current_size + len(data_dict['sequence_id'])


### PR DESCRIPTION
Update code to use encoded hdf5 dataset, the custom iterable dataset for inference, and compute embeddings for all records.

In particular
- instead of storing embeddings in json, use one hdf5 file per model
- Re-use the `CustomIterableDataset` for running inference. Small changes to handle inference, and add the `len` method
- add functionality to choose datatype for the arrays in `write_to_hdf5`
- add slurm scripts and config files for each model