### PR TITLE
Create fake input data for LLM training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 *.pyo                # Ignore optimized compiled Python files
 *.pyd                # Ignore Windows specific Python extension files
 env_ossc/
+.venv/

--- a/src/others/synthetic_data_generation/create_fake_data.py
+++ b/src/others/synthetic_data_generation/create_fake_data.py
@@ -93,8 +93,6 @@ if __name__ == "__main__":
     n_obs = None
     if args.dry_run:
         n_obs = SAMPLE_SIZE_DRY_RUN
-    else:
-        raise NotImplementedError
 
     main(cfg=args.cfg, n_observations=n_obs)
 

--- a/src/others/synthetic_data_generation/create_fake_data.py
+++ b/src/others/synthetic_data_generation/create_fake_data.py
@@ -1,0 +1,93 @@
+"""
+Data Generation Script
+
+This script generates fake data based on summary statistics provided in a configuration file. 
+
+Usage:
+    Run the script from the command line with the necessary arguments for configuration file path and optional dry run mode.
+
+Args:
+    --cfg (str): Path to the configuration file (required).
+    --dry-run (bool): If specified, runs a test with a small output data size. 
+
+Example:
+    python create_fake_data.py --cfg path/to/config.json --dry-run
+
+Configuration File:
+    The configuration file should be a JSON file containing:
+        - "SUMMARY_STAT_DIR" (str): Directory containing summary statistics of multiple data files. 
+        - "ORIGINAL_ROOT" (str): Path to the root directory where the original data are stored.
+        - "NEW_ROOT" (str): Path to the root directory where the fake data are stored.
+        
+Constants:
+    SAMPLE_SIZE_DRY_RUN (int): Default sample size for dry run mode.
+    RANDOM_SEED (int): Seed for random number generation.
+"""
+
+
+import argparse
+import numpy as np 
+import os
+from tqdm import tqdm
+
+from src.others.synthetic_data_generation.fake_data_generator import FakeDataGenerator
+from src.others.synthetic_data_generation.utils import get_unique_source_files
+from src.llm.src.new_code.utils import read_json
+
+
+SAMPLE_SIZE_DRY_RUN = 1_000
+RANDOM_SEED = 935723583
+
+
+def main(cfg, n_observations=None):
+    """Generate data
+    
+    Args
+        cfg (dict): configuration file
+        n_observations (int, optional): size of the data to generate. If `None` (the default), size is taken from
+        the summary statistics.
+    """
+    cfg = read_json(cfg)
+
+    rng = np.random.default_rng(seed=RANDOM_SEED)
+    src_files = get_unique_source_files(cfg["SUMMARY_STAT_DIR"])
+
+    generator = FakeDataGenerator()
+    for src_file in tqdm(src_files):
+        url, filename = os.path.split(src_file)
+        generator.load_metadata(url=url, filename=filename)
+        generator.fit()
+        data = generator.generate(rng=rng, size=n_observations)
+        generator.save(
+            original_root=cfg["ORIGINAL_ROOT"],
+            new_root=cfg["NEW_ROOT"], 
+            data=data
+        )
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", 
+                        dest="dry_run", 
+                        help="If given, runs a test with a small output data size.",
+                        action=argparse.BooleanOptionalAction)
+    parser.add_argument("--cfg",
+                        type=str,
+                        help="Path to config file")
+
+    args = parser.parse_args()
+
+    n_obs = None
+    if args.dry_run:
+        n_obs = SAMPLE_SIZE_DRY_RUN
+    else:
+        raise NotImplementedError
+
+    main(cfg=args.cfg, n_observations=n_obs)
+
+
+    
+    
+
+

--- a/src/others/synthetic_data_generation/create_fake_data.py
+++ b/src/others/synthetic_data_generation/create_fake_data.py
@@ -28,6 +28,7 @@ Constants:
 import argparse
 import numpy as np 
 import os
+import logging
 from tqdm import tqdm
 
 from src.others.synthetic_data_generation.fake_data_generator import FakeDataGenerator
@@ -75,8 +76,19 @@ if __name__ == "__main__":
     parser.add_argument("--cfg",
                         type=str,
                         help="Path to config file")
+    parser.add_argument("--debug",
+                        action=argparse.BooleanOptionalAction)
 
     args = parser.parse_args()
+    logging_level = logging.DEBUG if args.debug else logging.INFO
+
+
+    logging.basicConfig(
+        format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        level=logging_level
+    )
+
 
     n_obs = None
     if args.dry_run:

--- a/src/others/synthetic_data_generation/create_fake_data.sh
+++ b/src/others/synthetic_data_generation/create_fake_data.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+#SBATCH --job-name=create_fake_data
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=15:00
+#SBATCH --mem=200MB
+#SBATCH -p work_env
+#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/synthetic/logs/%x.%j.err
+#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/synthetic/logs/%x.%j.out
+
+stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
+
+if stringContain "ossc" $USER; then
+    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
+else
+    declare DATADIR="/projects/0/prjs1019"
+fi 
+
+# add more users here as necessary
+if stringContain "ossc" $USER; then
+    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
+    declare VENV="$ROOTDIR/ossc_env"
+elif stringContain "fhafner" $USER; then 
+    declare ROOTDIR="/gpfs/home4/$USER"
+    declare VENV="$ROOTDIR/.venv"
+    declare REPO_DIR="$ROOTDIR/repositories/life-sequenceing-dutch"
+fi
+
+module purge 
+module load 2022 
+module load Python/3.10.4-GCCcore-11.3.0
+module load SciPy-bundle/2022.05-foss-2022a
+source "$VENV/bin/activate" 
+
+# DATAPATH="/gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/"
+
+echo "job started" 
+cd $REPO_DIR
+
+date
+time python src/others/synthetic_data_generation/create_fake_data.py \
+ --cfg src/others/synthetic_data_generation/fake_data_cfg.json \
+ --dry-run
+
+echo "job ended" 

--- a/src/others/synthetic_data_generation/create_fake_data.sh
+++ b/src/others/synthetic_data_generation/create_fake_data.sh
@@ -11,36 +11,51 @@
 
 stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
 
-if stringContain "ossc" $USER; then
-    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
-else
-    declare DATADIR="/projects/0/prjs1019"
-fi 
+# This function can be called with `source script.sh` -> fast initialization during interactive jobs
+initialize() {
+	# note that `declare` are local variables and will not be available out of function scope
 
-# add more users here as necessary
-if stringContain "ossc" $USER; then
-    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
-    declare VENV="$ROOTDIR/ossc_env"
-elif stringContain "fhafner" $USER; then 
-    declare ROOTDIR="/gpfs/home4/$USER"
-    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
-    declare VENV="$REPO_DIR/.venv"
+	if stringContain "ossc" $USER; then
+	    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
+	else
+	    declare DATADIR="/projects/0/prjs1019"
+	fi 
+	
+	# add more users here as necessary
+	if stringContain "ossc" $USER; then
+	    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
+	    declare VENV="$ROOTDIR/ossc_env"
+	elif stringContain "fhafner" $USER; then 
+	    declare ROOTDIR="/gpfs/home4/$USER"
+	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
+	    declare VENV="$REPO_DIR/.venv"
+	fi
+	
+	module purge 
+	module load 2022 
+	module load Python/3.10.4-GCCcore-11.3.0
+	module load SciPy-bundle/2022.05-foss-2022a
+	source "$VENV/bin/activate" 
+	
+	# DATAPATH="/gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/"
+	
+	echo "job started" 
+	cd $REPO_DIR
+}
+
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    initialize
+else
+    initialize
+   
+    date
+    time python -m src.others.synthetic_data_generation.create_fake_data \
+    --cfg src/others/synthetic_data_generation/fake_data_cfg.json \
+    --dry-run \
+    --debug
+
+    echo "job ended" 
 fi
 
-module purge 
-module load 2022 
-module load Python/3.10.4-GCCcore-11.3.0
-module load SciPy-bundle/2022.05-foss-2022a
-source "$VENV/bin/activate" 
 
-# DATAPATH="/gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/"
-
-echo "job started" 
-cd $REPO_DIR
-
-date
-time python -m src.others.synthetic_data_generation.create_fake_data \
- --cfg src/others/synthetic_data_generation/fake_data_cfg.json \
- --dry-run
-
-echo "job ended" 

--- a/src/others/synthetic_data_generation/create_fake_data.sh
+++ b/src/others/synthetic_data_generation/create_fake_data.sh
@@ -3,11 +3,11 @@
 #SBATCH --job-name=create_fake_data
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
-#SBATCH --time=15:00
-#SBATCH --mem=200MB
-#SBATCH -p work_env
-#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/synthetic/logs/%x.%j.err
-#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/synthetic/logs/%x.%j.out
+#SBATCH --time=00:02:00
+#SBATCH --mem=100MB
+#SBATCH -p rome 
+#SBATCH -e %x-%j.err
+#SBATCH -o %x-%j.out
 
 stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
 
@@ -23,8 +23,8 @@ if stringContain "ossc" $USER; then
     declare VENV="$ROOTDIR/ossc_env"
 elif stringContain "fhafner" $USER; then 
     declare ROOTDIR="/gpfs/home4/$USER"
-    declare VENV="$ROOTDIR/.venv"
-    declare REPO_DIR="$ROOTDIR/repositories/life-sequenceing-dutch"
+    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
+    declare VENV="$REPO_DIR/.venv"
 fi
 
 module purge 
@@ -39,7 +39,7 @@ echo "job started"
 cd $REPO_DIR
 
 date
-time python src/others/synthetic_data_generation/create_fake_data.py \
+time python -m src.others.synthetic_data_generation.create_fake_data \
  --cfg src/others/synthetic_data_generation/fake_data_cfg.json \
  --dry-run
 

--- a/src/others/synthetic_data_generation/create_fake_data.sh
+++ b/src/others/synthetic_data_generation/create_fake_data.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 #
 #SBATCH --job-name=create_fake_data
-#SBATCH --ntasks-per-node=1
+#SBATCH --ntasks-per-node=50
 #SBATCH --nodes=1
-#SBATCH --time=00:02:00
-#SBATCH --mem=100MB
+#SBATCH --time=00:30:00
+#SBATCH --mem=5GB
 #SBATCH -p rome 
 #SBATCH -e %x-%j.err
 #SBATCH -o %x-%j.out
 
+# function to check if $2 is in $1
 stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
 
 # This function can be called with `source script.sh` -> fast initialization during interactive jobs
@@ -51,9 +52,7 @@ else
    
     date
     time python -m src.others.synthetic_data_generation.create_fake_data \
-    --cfg src/others/synthetic_data_generation/fake_data_cfg.json \
-    --dry-run \
-    --debug
+    --cfg src/others/synthetic_data_generation/fake_data_cfg.json 
 
     echo "job ended" 
 fi

--- a/src/others/synthetic_data_generation/fake_data_cfg.json
+++ b/src/others/synthetic_data_generation/fake_data_cfg.json
@@ -1,0 +1,5 @@
+{
+    "SUMMARY_STAT_DIR": "/home/flavio/OneDrive/NLeSC/Projects/2024_life2vec/stakeholders/CBS/exports/2024-05-14/data/llm",
+    "ORIGINAL_ROOT": "/gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects//dutch_real/",
+    "NEW_ROOT": "/home/flavio/datasets/test/llm_data/"
+}

--- a/src/others/synthetic_data_generation/fake_data_cfg.json
+++ b/src/others/synthetic_data_generation/fake_data_cfg.json
@@ -1,5 +1,5 @@
 {
-    "SUMMARY_STAT_DIR": "/home/flavio/OneDrive/NLeSC/Projects/2024_life2vec/stakeholders/CBS/exports/2024-05-14/data/llm",
+    "SUMMARY_STAT_DIR": "/projects/0/prjs1019/data/uploads/export_2024-05-14/data/llm/",
     "ORIGINAL_ROOT": "/gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects//dutch_real/",
-    "NEW_ROOT": "/home/flavio/datasets/test/llm_data/"
+    "NEW_ROOT": "/projects/0/prjs1019/data/llm/raw/"
 }

--- a/src/others/synthetic_data_generation/fake_data_generator.py
+++ b/src/others/synthetic_data_generation/fake_data_generator.py
@@ -4,6 +4,7 @@ import pandas as pd
 import json 
 import os
 import re 
+import math
 from .utils import split_at_last_match
 import logging
 
@@ -217,7 +218,8 @@ def detect_variable_type(row, max_diff_q10_q90=10):
     result_dict["null_fraction"] = row["null_fraction"]
     
     if "probs" in result_dict.keys():
-        if sum(result_dict["probs"]) != 1:
+        probs_sum = sum(result_dict["probs"])
+        if not math.isclose(1, probs_sum):
             logging.debug("probs do not sum to one!")
     
     return result_dict

--- a/src/others/synthetic_data_generation/fake_data_generator.py
+++ b/src/others/synthetic_data_generation/fake_data_generator.py
@@ -1,0 +1,214 @@
+
+import numpy as np 
+import pandas as pd 
+import json 
+import os
+import re 
+
+class FakeDataGenerator: 
+    """Class to read file with data summary stats.
+    """
+
+    def __init__(self):
+        self.meta = None
+        self.col_summary = None
+
+
+    def _path_end(self, path_start):
+        "From the path to the original file, strip the start string and return the end string."
+        full_path = self.meta.get("path")
+        assert path_start in full_path, "invalid start of path provided"
+        return re.sub(path_start, "", full_path)
+    
+
+    def save(self, original_root, new_root, data):
+        """Save the data to a data root directory with the correct format.
+
+        The new path is defined as follows. From the full original path, `original_root` is cropped and
+        replaced with `new_root`. Any remainder of the original path is considered immutable and left unchanged.    
+        
+        Args:
+            original_root (str): original root directory of the source file.
+            new_root (str): new root directory of the data.
+            data (pd.DataFrame): data frame to store
+        """
+        immutable_part = self._path_end(original_root)
+        filename = os.path.join(new_root, immutable_part)
+        target_dir, _ = os.path.split(filename)
+        if not os.path.isdir(target_dir):
+            os.makedirs(target_dir)
+
+        if "csv" in filename:
+            data.to_csv(filename, index=False)
+        else:
+            _, filetype = split_at_last_match(filename, "\.")
+            raise NotImplementedError("Cannot save as %s file type" % filetype)
+
+        # XXX deal with different file formats
+
+
+    def load_metadata(self, url, filename):
+        """Load meta data and column summaries
+
+        Arguments:
+            url (str): local path where the summary files are stored
+            filename (str): the name of the original data file 
+        """
+        with open(os.path.join(url, filename + "_meta.txt"), "r") as f:
+            self.meta = dict(json.load(f))
+        
+        self.col_summary = pd.read_csv(os.path.join(url, filename + "_columns.csv"))
+
+
+    def fit(self):
+        """Process metadata and summary statistics to define how each column should be generated.
+        """
+        results = {}
+        for _, row in self.col_summary.iterrows():
+            variable = row["variable_name"]
+            results[variable] = detect_variable_type(row)
+        
+        self.generation_inputs = results
+
+
+    def generate(self, rng, size=None):
+        """Generate new data while
+            - enforcing non-negativity of numerical variables
+            - considering PII columns: each column is an integer range from 0 to `size`. 
+            - considering null fractions
+        
+        Args:
+            rng (np.random.default_rng): random number generator
+            n (int, optional): Size of sample to generate. If `None`, the size is taken from
+            the data summary.
+
+        Returns:
+            pd.DataFrame: the generated data
+        """
+        assert self.generation_inputs, "You need to `fit` before calling `generate`."
+        if size is None:
+            size = self.meta.get("total_nobs")
+        column_dtypes = self.meta.get("columns_with_dtypes")
+
+        data = {}
+
+        pii_cols = self.meta.get("has_pii_columns")
+        for pc in pii_cols:
+            data[pc] = np.arange(size)
+
+        for colname, inputs in self.generation_inputs.items(): 
+            required_dtype = column_dtypes.get(colname)
+            implemented_types = ["object", "int64"]
+            if required_dtype not in implemented_types:
+                raise NotImplementedError("data type %s not implemented" % required_dtype)
+        
+            n_nulls = int(size * inputs["null_fraction"])
+            n_nonulls = size - n_nulls 
+
+            if inputs["type"] == "categorical":
+                col_data = rng.choice(a=inputs["classes"], size=n_nonulls, p=inputs["probs"])
+            elif inputs["type"] == "continuous":
+                col_data = generate_continuous_column(
+                    rng, inputs["mean"], inputs["std_dev"], n_nonulls, inputs["min"]
+                )
+                if required_dtype == "int64":
+                    col_data = np.int64(np.round(col_data))
+
+            col_data = add_nans(rng, col_data, n_nulls)
+            data[colname] = col_data
+
+        return pd.DataFrame(data)
+
+
+
+def generate_continuous_column(rng, mean, std_dev, size, min_value):
+    """Create a column of continuous data; deal with undesired negative values.
+
+    Args:
+        rng (np.random.default_rng): random number generator
+        mean, std_dev (float): mean and std for the generated data
+        size (int): size of the generated data
+        min_value (float): minimum value to be enforced onto the generated data
+    """
+    col_data = rng.normal(mean, std_dev, size) 
+    negatives = np.where(col_data < 0)
+    col_data[negatives] = min_value
+    return col_data
+
+
+def add_nans(rng, data, size):
+    "add NaNs to an existing array"
+    nulls = np.tile(np.nan, size)
+    data = np.concatenate([nulls, data])
+    rng.shuffle(data)
+    return data
+
+
+
+
+
+def detect_variable_type(row, max_diff_q10_q90=10):
+    """Detect how a fake variable should be generated.
+
+    A column is detected as categorical if one of two conditions hold
+    - it has at least one category reported
+    - it has no category reported, but the summary statistics
+      suggest only a limited number of possible classes.
+
+    Because the min is not available in the summaries, the function 
+    assigns p10 in the actual data to be the min in the data to be generated.
+
+    Args:
+        row (dict): a row from a pd.DataFrame
+        max_diff_q10_q90 (int, optional): The maximum difference 
+        between the 10th and 90th percentile in the empirical distribution.
+        This is used to infer the second case of categorical variables.
+
+    Returns:
+        dict: instructions to generate random variables.
+    
+    """
+    category_0 = row["category_top_0"]
+    if isinstance(category_0, str):
+        top_cats = [row[f"category_top_{i}"] for i in range(5)]
+        top_cats = [x for x in top_cats if isinstance(x, str)]
+        top_cats = [x.split("--") for x in top_cats]
+        classes = [x[0] for x in top_cats]
+        probs = [float(x[1]) for x in top_cats]
+        result_dict = {
+            "type": "categorical",
+            "classes": classes,
+            "probs": probs
+        }
+    else:
+        p10, p90 = row["10th_percentile"], row["90th_percentile"]
+        if p90 - p10 <= max_diff_q10_q90:
+            pdiff = int(p90) - int(p10)
+            # we want to include the end of the range, and deal with cases where p10=p90
+            addon = 1 if pdiff > 0 else 2
+            p90 += addon
+            pdiff += addon
+            result_dict = {
+                "type": "categorical",
+                "classes": np.arange(int(p10), int(p90)),
+                "probs": [1/pdiff for _ in range(pdiff)]
+            } 
+        else:
+            result_dict = {
+                "type": "continuous",
+                "mean": row["mean"],
+                "std_dev": row["std_dev"],
+                "min": p10
+            }
+
+    result_dict["null_fraction"] = row["null_fraction"]
+    
+    return result_dict
+    
+
+def split_at_last_match(s, p):
+    "Split a string `s` at the last occurence of `p`"
+    last_match = list(re.finditer(p, s))[-1]
+    first = s[:last_match.end()-1]
+    second = s[last_match.end():]
+    return first, second

--- a/src/others/synthetic_data_generation/fake_data_generator.py
+++ b/src/others/synthetic_data_generation/fake_data_generator.py
@@ -4,9 +4,20 @@ import pandas as pd
 import json 
 import os
 import re 
+from .utils import split_at_last_match
 
 class FakeDataGenerator: 
-    """Class to read file with data summary stats.
+    """Class to generate fake data from summary statistics.
+
+    The class is intended to work with summary statistics that are created with `gen_spreadsheets.py`, and in particular
+    requires that each data source is associated with three summary files:
+    - *_meta.json: metadata about the data source
+    - *_columns.csv
+    - *_covariance.csv
+    where * is the name of the original data source.
+
+    - For PII variables, it is assumed that each PII identifier is associated with one row.    
+    - For numerical variables with a low interquartile range (IQR), the unique integers from the range are drawn with equal probability.
     """
 
     def __init__(self):
@@ -48,7 +59,7 @@ class FakeDataGenerator:
 
 
     def load_metadata(self, url, filename):
-        """Load meta data and column summaries
+        """Load meta data and column summaries.
 
         Arguments:
             url (str): local path where the summary files are stored
@@ -144,9 +155,6 @@ def add_nans(rng, data, size):
     return data
 
 
-
-
-
 def detect_variable_type(row, max_diff_q10_q90=10):
     """Detect how a fake variable should be generated.
 
@@ -206,9 +214,3 @@ def detect_variable_type(row, max_diff_q10_q90=10):
     return result_dict
     
 
-def split_at_last_match(s, p):
-    "Split a string `s` at the last occurence of `p`"
-    last_match = list(re.finditer(p, s))[-1]
-    first = s[:last_match.end()-1]
-    second = s[last_match.end():]
-    return first, second

--- a/src/others/synthetic_data_generation/utils.py
+++ b/src/others/synthetic_data_generation/utils.py
@@ -1,7 +1,8 @@
 import numpy as np 
 import pyreadstat
-import logging
 import pandas as pd 
+import os 
+import re 
 
 def check_column_names(column_names, names_to_check):
     "Check if a colum name matches exactly, or on a substring, the names to check."
@@ -77,3 +78,41 @@ def sample_from_file(source_file_path, n_rows):
 
   return df, nobs
 
+
+def yield_filepaths(root):
+  "Yield full paths to all files in `root` and its subdirs"
+  for root, _, files in os.walk(root):
+      for filename in files:
+          filename = os.path.join(root, filename)
+          if os.path.isfile(filename): 
+              yield filename   
+
+
+def get_unique_source_files(root):
+  """Return full paths to unique data files.
+
+  Deals with the files of summary statistics generated from data. 
+
+  Args:
+    root (str): root directory to search
+
+
+  Example: from ["data1_meta.json", "data1_covariance.csv", "data1_columns.csv"] it returns "data1".
+  """
+  files = list(yield_filepaths(root))
+  src_files = set()
+
+  for f in files:
+    src_file, _ = split_at_last_match(f, "_")
+    src_files.add(src_file)
+
+  return src_files
+
+
+
+def split_at_last_match(s, p):
+  "Split a string `s` at the last occurence of `p`"
+  last_match = list(re.finditer(p, s))[-1]
+  first = s[:last_match.end()-1]
+  second = s[last_match.end():]
+  return first, second


### PR DESCRIPTION
This is a first step for https://github.com/odissei-lifecourse/life-sequencing-dutch/issues/40.

Changes are in `src/others/synthetic_data_generation/`
- `fake_data_generator.py`: create fake data with `load_metadata`, `fit` and `generate`
- `create_fake_data.py`: iterates over all files in a directory (specified in the config json) and creates fake data from them, using the class defined in `fake_data_generator.py`.
- `create_fake_data.sh`: bash script to run on snellius.
   - I separated the steps for initialization (modules, venv) so that one can load them also quickly on a interactive job with `source create_fake_data.sh`
   - added options for `dry-run` and for `debug`
- `utils.py`: add function to process names of unique data source files
- `fake_data_cfg.json` has the inputs. 


In the future, this should be reusable for generating other fake data, in particular from the original CBS tables. 

Missing features
- can only handle csv source files; will need updating 
- data distributions are simple: no covariance; simplifying assumptions for variables with small IQRs

