### PR TITLE
LLM pipeline on Snellius

### DIFF
--- a/src/llm/projects/dutch_real/create_json_seq_cfg.json
+++ b/src/llm/projects/dutch_real/create_json_seq_cfg.json
@@ -1,7 +1,7 @@
 {
-  "data_directory_path": "projects/dutch_real/data/",
-  "SEQUENCE_WRITE_PATH": "projects/dutch_real/gen_data/people.json",
-  "vocab_write_path": "projects/dutch_real/gen_data/vocab.csv",
+  "data_directory_path": "/projects/0/prjs1019/data/llm/raw/data/",
+  "SEQUENCE_WRITE_PATH": "/projects/0/prjs1019/data/llm/processed/people.json",
+  "vocab_write_path": "/projects/0/prjs1019/data/llm/processed/vocab.csv",
   "primary_key": "RINPERSOON",
   "vocab_name": "dutch_vocab_2017_v0"
 }

--- a/src/llm/projects/dutch_real/pipeline_cfg.json
+++ b/src/llm/projects/dutch_real/pipeline_cfg.json
@@ -1,14 +1,14 @@
 {
-  "data_directory_path": "projects/dutch_real/data/",
-  "SEQUENCE_PATH": "projects/dutch_real/gen_data/people.json",
-  "vocab_write_path": "projects/dutch_real/gen_data/vocab.csv",
-  "MLM_WRITE_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017.h5",
+  "data_directory_path": "/projects/0/prjs1019/data/llm/raw/data/",
+  "SEQUENCE_PATH": "/projects/0/prjs1019/data/llm/processed/people.json",
+  "vocab_write_path": "/projects/0/prjs1019/data/llm/processed/vocab.csv",
+  "MLM_WRITE_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017.h5",
   "DO_MLM": true,
   "primary_key": "RINPERSOON",
   "vocab_name": "dutch_vocab_2017_v0",
   "TIME_KEY": "daysSinceFirstEvent",
   "TIME_RANGE_END": 16438,
   "SHUFFLE": true,
-  "PARALLEL": true,
+  "PARALLEL": false,
   "CHUNK_SIZE": 10000
 }

--- a/src/llm/projects/dutch_real/pipeline_cfg.json
+++ b/src/llm/projects/dutch_real/pipeline_cfg.json
@@ -2,7 +2,7 @@
   "data_directory_path": "/projects/0/prjs1019/data/llm/raw/data/",
   "SEQUENCE_PATH": "/projects/0/prjs1019/data/llm/processed/people.json",
   "vocab_write_path": "/projects/0/prjs1019/data/llm/processed/vocab.csv",
-  "MLM_WRITE_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017.h5",
+  "MLM_WRITE_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017",
   "DO_MLM": true,
   "primary_key": "RINPERSOON",
   "vocab_name": "dutch_vocab_2017_v0",

--- a/src/llm/projects/dutch_real/pretrain_cfg.json
+++ b/src/llm/projects/dutch_real/pretrain_cfg.json
@@ -3,5 +3,5 @@
   "CHECKPOINT_DIR": "/projects/0/prjs1019/data/llm/models/2017_checkpoints_0/",   
   "MLM_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017.h5",
   "MAX_EPOCHS": 30,
-  "BATCH_SIZE": 192
+  "BATCH_SIZE": 500
 }

--- a/src/llm/projects/dutch_real/pretrain_cfg.json
+++ b/src/llm/projects/dutch_real/pretrain_cfg.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "src/new_code/regular_hparams.txt",
-  "CHECKPOINT_DIR": "projects/dutch_real/2017_checkpoints_0/",   
-  "MLM_PATH": "projects/dutch_real/gen_data/mlm_encoded_upto_2017",
+  "CHECKPOINT_DIR": "/projects/0/prjs1019/data/llm/models/2017_checkpoints_0/",   
+  "MLM_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017.h5",
   "MAX_EPOCHS": 30,
   "BATCH_SIZE": 192
 }

--- a/src/llm/projects/dutch_real/pretrain_cfg.json
+++ b/src/llm/projects/dutch_real/pretrain_cfg.json
@@ -3,5 +3,5 @@
   "CHECKPOINT_DIR": "/projects/0/prjs1019/data/llm/models/2017_checkpoints_0/",   
   "MLM_PATH": "/projects/0/prjs1019/data/llm/processed/mlm_encoded_upto_2017.h5",
   "MAX_EPOCHS": 30,
-  "BATCH_SIZE": 500
+  "BATCH_SIZE": 192
 }

--- a/src/llm/slurm_scripts/2023_snel_modules.sh
+++ b/src/llm/slurm_scripts/2023_snel_modules.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-module purge
-module load 2023
-module load Python/3.11.3-GCCcore-12.3.0
-module load PyTorch/2.1.2-foss-2023a-CUDA-12.1.1
-module load matplotlib/3.7.2-gfbf-2023a
-module load h5py/3.9.0-foss-2023a
-

--- a/src/llm/slurm_scripts/2023_snel_modules.sh
+++ b/src/llm/slurm_scripts/2023_snel_modules.sh
@@ -2,6 +2,7 @@
 
 module purge
 module load 2023
+module load Python/3.11.3-GCCcore-12.3.0
 module load PyTorch/2.1.2-foss-2023a-CUDA-12.1.1
 module load matplotlib/3.7.2-gfbf-2023a
 module load h5py/3.9.0-foss-2023a

--- a/src/llm/slurm_scripts/2023_snel_modules.sh
+++ b/src/llm/slurm_scripts/2023_snel_modules.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+module purge
+module load 2023
+module load PyTorch/2.1.2-foss-2023a-CUDA-12.1.1
+module load matplotlib/3.7.2-gfbf-2023a
+module load h5py/3.9.0-foss-2023a
+

--- a/src/llm/slurm_scripts/create_json_seq.sh
+++ b/src/llm/slurm_scripts/create_json_seq.sh
@@ -31,11 +31,8 @@ initialize() {
 	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
 	    declare VENV="$REPO_DIR/.venv"
 	fi
-	
-	module purge 
-	module load 2022 
-	module load Python/3.10.4-GCCcore-11.3.0
-	module load SciPy-bundle/2022.05-foss-2022a
+
+	source $REPO_DIR/requirements/2023_snel_modules.sh	
 	source "$VENV/bin/activate" 
 	
 	echo "job started" 

--- a/src/llm/slurm_scripts/create_json_seq.sh
+++ b/src/llm/slurm_scripts/create_json_seq.sh
@@ -43,7 +43,6 @@ initialize() {
 
 echo "job started"
 
-#cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
 
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
     initialize

--- a/src/llm/slurm_scripts/create_json_seq.sh
+++ b/src/llm/slurm_scripts/create_json_seq.sh
@@ -1,19 +1,62 @@
 #!/bin/bash
 #
-#SBATCH --job-name=pipeline
+#SBATCH --job-name=create_json_seq
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
-#SBATCH --time=03:00:00
-#SBATCH --mem=240G
-#SBATCH -p comp_env
-#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/create_json_seq_stderr.txt
-#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/create_json_seq_stdout.txt
+#SBATCH --time=01:30:00
+#SBATCH --mem=200G
+#SBATCH -p fat_rome 
+#SBATCH -e %x-%j.err
+#SBATCH -o %x-%j.out
+
+# function to check if $2 is in $1
+stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
+
+# This function can be called with `source script.sh` -> fast initialization during interactive jobs
+initialize() {
+	# note that `declare` are local variables and will not be available out of function scope
+
+	if stringContain "ossc" $USER; then
+	    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
+	else
+	    declare DATADIR="/projects/0/prjs1019"
+	fi 
+	
+	# add more users here as necessary
+	if stringContain "ossc" $USER; then
+	    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
+	    declare VENV="$ROOTDIR/ossc_env"
+	elif stringContain "fhafner" $USER; then 
+	    declare ROOTDIR="/gpfs/home4/$USER"
+	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
+	    declare VENV="$REPO_DIR/.venv"
+	fi
+	
+	module purge 
+	module load 2022 
+	module load Python/3.10.4-GCCcore-11.3.0
+	module load SciPy-bundle/2022.05-foss-2022a
+	source "$VENV/bin/activate" 
+	
+	echo "job started" 
+	cd $REPO_DIR/src/llm/
+}
+
+
 
 echo "job started"
 
-cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
+#cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
 
-date
-time python -m src.new_code.create_life_seq_jsons projects/dutch_real/create_json_seq_cfg.json
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    initialize
+else
+    initialize
 
-echo "job ended successfully"
+    date
+    time python -m src.new_code.create_life_seq_jsons projects/dutch_real/create_json_seq_cfg.json
+
+    echo "job ended"
+fi
+
+

--- a/src/llm/slurm_scripts/pipeline.sh
+++ b/src/llm/slurm_scripts/pipeline.sh
@@ -2,25 +2,61 @@
 #
 #SBATCH --job-name=pipeline
 #SBATCH --ntasks 1
-#SBATCH --cpus-per-task 72
+#SBATCH --cpus-per-task 4 
 #SBATCH --nodes=1
-#SBATCH --time=12:00:00
-#SBATCH --mem=900G
-#SBATCH -p comp_env
-#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
-#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+#SBATCH --time=02:30:00
+#SBATCH --mem=20G
+#SBATCH -p fat_rome
+#SBATCH -e %x-%j.err
+#SBATCH -o %x-%j.out
 
-echo "job started"
 
-cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
+# function to check if $2 is in $1
+stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
 
-module load 2022
-module load Python/3.10.4-GCCcore-11.3.0
+# This function can be called with `source script.sh` -> fast initialization during interactive jobs
+initialize() {
+	# note that `declare` are local variables and will not be available out of function scope
 
-source ossc_env_may2/bin/activate 
+	if stringContain "ossc" $USER; then
+	    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
+	else
+	    declare DATADIR="/projects/0/prjs1019"
+	fi 
+	
+	# add more users here as necessary
+	if stringContain "ossc" $USER; then
+	    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
+	    declare VENV="$ROOTDIR/ossc_env"
+	elif stringContain "fhafner" $USER; then 
+	    declare ROOTDIR="/gpfs/home4/$USER"
+	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
+	    declare VENV="$REPO_DIR/.venv"
+	fi
+	
+	module purge 
+	module load 2022 
+	module load Python/3.10.4-GCCcore-11.3.0
+	module load SciPy-bundle/2022.05-foss-2022a
+        module load h5py/3.7.0-foss-2022a
+	source "$VENV/bin/activate" 
+	
+	echo "job started" 
+	cd $REPO_DIR/src/llm/
+}
 
-date
-srun python -m src.new_code.pipeline projects/dutch_real/pipeline_cfg.json
+#cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
 
-echo "job ended"
+#source ossc_env_may2/bin/activate 
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    initialize
+else
+    initialize
+
+    date
+    srun python -m src.new_code.pipeline projects/dutch_real/pipeline_cfg.json
+
+    echo "job ended"
+fi
 

--- a/src/llm/slurm_scripts/pipeline.sh
+++ b/src/llm/slurm_scripts/pipeline.sh
@@ -41,9 +41,6 @@ initialize() {
 	cd $REPO_DIR/src/llm/
 }
 
-#cd /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/ 
-
-#source ossc_env_may2/bin/activate 
 
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
     initialize

--- a/src/llm/slurm_scripts/pipeline.sh
+++ b/src/llm/slurm_scripts/pipeline.sh
@@ -33,12 +33,8 @@ initialize() {
 	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
 	    declare VENV="$REPO_DIR/.venv"
 	fi
-	
-	module purge 
-	module load 2022 
-	module load Python/3.10.4-GCCcore-11.3.0
-	module load SciPy-bundle/2022.05-foss-2022a
-        module load h5py/3.7.0-foss-2022a
+
+	source $REPO_DIR/requirements/2023_snel_modules.sh	
 	source "$VENV/bin/activate" 
 	
 	echo "job started" 

--- a/src/llm/slurm_scripts/pretrain.sh
+++ b/src/llm/slurm_scripts/pretrain.sh
@@ -3,12 +3,13 @@
 #SBATCH --job-name=pretrain
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
-#SBATCH --time=03:00:00
-#SBATCH --cpus-per-task=36
-#SBATCH --mem=180G
+#SBATCH --time=00:10:00
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --gpus-per-node=1
 #SBATCH -p gpu 
-#SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
-#SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
+#SBATCH -e %x-%j.err 
+#SBATCH -o %x-%j.out 
 
 
 
@@ -38,7 +39,7 @@ initialize() {
 	module purge 
 	module load 2022 
 	module load Python/3.10.4-GCCcore-11.3.0
-       # module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+        #module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
 	module load SciPy-bundle/2022.05-foss-2022a
         module load h5py/3.7.0-foss-2022a
 	module load matplotlib/3.5.2-foss-2022a
@@ -54,7 +55,7 @@ initialize() {
 
 main() {
 	date
-	time python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
+	CUDA_LAUNCH_BLOCKING=1 python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
 	
 	echo "job ended"
 }

--- a/src/llm/slurm_scripts/pretrain.sh
+++ b/src/llm/slurm_scripts/pretrain.sh
@@ -54,8 +54,11 @@ initialize() {
 
 
 main() {
+	# NOTE: changes in this file require changes in pretrain.py
 	date
 	python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
+ 	#srun --mpi=pmi2 python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json	
+ 	#python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
 	# for debugging on GPU
 	#CUDA_LAUNCH_BLOCKING=1 python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
         # for debugging on CPU 

--- a/src/llm/slurm_scripts/pretrain.sh
+++ b/src/llm/slurm_scripts/pretrain.sh
@@ -3,7 +3,7 @@
 #SBATCH --job-name=pretrain
 #SBATCH --ntasks-per-node=1
 #SBATCH --nodes=1
-#SBATCH --time=00:10:00
+#SBATCH --time=00:30:00
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=64G
 #SBATCH --gpus-per-node=1
@@ -55,8 +55,11 @@ initialize() {
 
 main() {
 	date
-	CUDA_LAUNCH_BLOCKING=1 python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
-	
+	python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
+	# for debugging on GPU
+	#CUDA_LAUNCH_BLOCKING=1 python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
+        # for debugging on CPU 
+	#python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json	
 	echo "job ended"
 }
 

--- a/src/llm/slurm_scripts/pretrain.sh
+++ b/src/llm/slurm_scripts/pretrain.sh
@@ -6,29 +6,73 @@
 #SBATCH --time=03:00:00
 #SBATCH --cpus-per-task=36
 #SBATCH --mem=180G
-#SBATCH -p comp_env
+#SBATCH -p gpu 
 #SBATCH -e /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.err
 #SBATCH -o /gpfs/ostor/ossc9424/homedir/Tanzir/LifeToVec_Nov/projects/dutch_real/logs/%x.%j.out
 
-HOMEDIR="/gpfs/ostor/ossc9424/homedir/"
-VENV="ossc_new/"
 
-echo "job started"
 
-module purge 
-module load 2022 
-module load Python/3.10.4-GCCCore-11.3.0
-module load PyTorch/1.12.0-foss-CUDA-11.7.0
-module load SciPy-bundle/2022.05-foss-2022a
-module load matplotlib/3.5.2-foss-2022a
-source "$HOMEDIR"/"$VENV"/bin/activate
+# function to check if $2 is in $1
+stringContain() { case $2 in *$1* ) return 0;; *) return 1;; esac ;}
 
-echo "job started" 
-export CUDA_VISIBLE_DEVICES=0
+# This function can be called with `source script.sh` -> fast initialization during interactive jobs
+initialize() {
+	# note that `declare` are local variables and will not be available out of function scope
 
-cd "$HOMEDIR"/Tanzir/LifeToVec_Nov/
+	if stringContain "ossc" $USER; then
+	    declare DATADIR="/gpfs/ostor/ossc9424/homedir/data"
+	else
+	    declare DATADIR="/projects/0/prjs1019"
+	fi 
+	
+	# add more users here as necessary
+	if stringContain "ossc" $USER; then
+	    declare ROOTDIR="/gpfs/ostor/ossc9424/homedir"
+	    declare VENV="$ROOTDIR/ossc_env"
+	elif stringContain "fhafner" $USER; then 
+	    declare ROOTDIR="/gpfs/home4/$USER"
+	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
+	    declare VENV="$REPO_DIR/.venv"
+	fi
+	
+	module purge 
+	module load 2022 
+	module load Python/3.10.4-GCCcore-11.3.0
+       # module load PyTorch/1.12.0-foss-2022a-CUDA-11.7.0
+	module load SciPy-bundle/2022.05-foss-2022a
+        module load h5py/3.7.0-foss-2022a
+	module load matplotlib/3.5.2-foss-2022a
+	source "$VENV/bin/activate" 
+	
+	cd $REPO_DIR/src/llm/
+        export CUDA_VISIBLE_DEVICES=0
+       
 
-date
-time python -m src.new_code/pretrain projects/dutch_real/pretrain_cfg.json
+        echo "job started" 
+}
 
-echo "job ended successfully"
+
+main() {
+	date
+	time python -m src.new_code.pretrain projects/dutch_real/pretrain_cfg.json
+	
+	echo "job ended"
+}
+
+
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    initialize
+else
+    initialize
+    main
+fi
+
+
+
+#	cd "$HOMEDIR"/Tanzir/LifeToVec_Nov/
+
+
+
+
+

--- a/src/llm/slurm_scripts/pretrain.sh
+++ b/src/llm/slurm_scripts/pretrain.sh
@@ -34,8 +34,13 @@ initialize() {
 	    declare ROOTDIR="/gpfs/home4/$USER"
 	    declare REPO_DIR="$ROOTDIR/repositories/life-sequencing-dutch"
 	    declare VENV="$REPO_DIR/.venv"
-	fi
+	elif stringContain "benjamic" $USER; then 
+	    declare ROOTDIR="/home/$USER"
+	    declare REPO_DIR="$ROOTDIR/life-sequencing-dutch"
+	    declare VENV="$REPO_DIR/.venv"
+	fi	
 	
+	echo $VENV
 	module purge 
 	module load 2022 
 	module load Python/3.10.4-GCCcore-11.3.0
@@ -49,7 +54,7 @@ initialize() {
         export CUDA_VISIBLE_DEVICES=0
        
 
-        echo "job started" 
+        echo "Modules loaded." 
 }
 
 

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -3,6 +3,7 @@
 #SBATCH --job-name=pretrain
 #SBATCH -p gpu
 #SBATCH --gpus-per-node=4
+#SBATCH --ntasks-per-node=4
 #SBATCH -t 00:30:00
 #SBATCH -e %x-%j.err 
 #SBATCH -o %x-%j.out 
@@ -12,7 +13,7 @@ export REPO_DIR=$ROOT_DIR/repositories/life-sequencing-dutch
 export VENV=$REPO_DIR/.venv/bin/activate
 
 #load the modules
-source $REPO_DIR/requirements/2023_snel_modules.sh
+source $REPO_DIR/requirements/snel_modules_2023.sh
 
 #source the virtual environment
 source $VENV
@@ -21,9 +22,9 @@ source $VENV
 cd $REPO_DIR/src/llm/
 
 #Start training
-python -m src.new_code.pretrain \
+srun python -m src.new_code.pretrain \
        --accelerator gpu \
-       --ddpstrategy gloo \
+       --ddpstrategy auto \
        --device $SLURM_GPUS_ON_NODE \
        --batch 256 \
        --hparams src/new_code/regular_hparams_large.txt \

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -12,7 +12,7 @@ export REPO_DIR=$ROOT_DIR/repositories/life-sequencing-dutch
 export VENV=$REPO_DIR/.venv/bin/activate
 
 #load the modules
-source $REPO_DIR/src/llm/slurm_scripts/2023_snel_modules.sh
+source $REPO_DIR/requirements/2023_snel_modules.sh
 
 #source the virtual environment
 source $VENV

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -29,6 +29,3 @@ python -m src.new_code.pretrain \
        --hparams src/new_code/regular_hparams_large.txt \
        --config projects/dutch_real/pretrain_cfg.json
 
-
-#python -m src.new_code.pretrain --accelerator gpu --ddpstrategy auto --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
-

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#SBATCH -p gpu_sw
+#SBATCH --gpus-per-node=4
+#SBATCH --exclusive
+#SBATCH -t 00:30:00
+
+
+export ROOT_DIR=/home/benjamic
+export REPO_DIR=$ROOT_DIR/life-sequencing-dutch
+export VENV=$REPO_DIR/.venv/bin/activate
+
+#load the modules
+source $REPO_DIR/src/llm/slurm_scripts/2023_snel_modules.sh
+
+#source the virtual environment
+source $VENV
+
+# Move to location
+cd $REPO_DIR/src/llm/
+
+#Start training
+python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device 2 --config projects/dutch_real/pretrain_cfg.json
+

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -7,8 +7,8 @@
 #SBATCH -e %x-%j.err 
 #SBATCH -o %x-%j.out 
 
-export ROOT_DIR=/home/benjamic
-export REPO_DIR=$ROOT_DIR/life-sequencing-dutch
+export ROOT_DIR=/home/fhafner/
+export REPO_DIR=$ROOT_DIR/repositories/life-sequencing-dutch
 export VENV=$REPO_DIR/.venv/bin/activate
 
 #load the modules
@@ -21,5 +21,6 @@ source $VENV
 cd $REPO_DIR/src/llm/
 
 #Start training
-python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
+#python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
+python -m src.new_code.pretrain --accelerator gpu --ddpstrategy auto --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
 

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-#SBATCH -p gpu_sw
-#SBATCH --gpus-per-node=4
-#SBATCH --exclusive
+#SBATCH --job-name=pretrain
+#SBATCH -p gpu
+#SBATCH --gpus-per-node=2
 #SBATCH -t 00:30:00
-
+#SBATCH -e %x-%j.err 
+#SBATCH -o %x-%j.out 
 
 export ROOT_DIR=/home/benjamic
 export REPO_DIR=$ROOT_DIR/life-sequencing-dutch
@@ -20,5 +21,5 @@ source $VENV
 cd $REPO_DIR/src/llm/
 
 #Start training
-python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device 2 --config projects/dutch_real/pretrain_cfg.json
+python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
 

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -21,6 +21,14 @@ source $VENV
 cd $REPO_DIR/src/llm/
 
 #Start training
-#python -m src.new_code.pretrain --accelerator gpu --ddpstrategy gloo --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
-python -m src.new_code.pretrain --accelerator gpu --ddpstrategy auto --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
+python -m src.new_code.pretrain \
+       --accelerator gpu \
+       --ddpstrategy auto \
+       --device $SLURM_GPUS_ON_NODE \
+       --batch 256 \
+       --hparams src/new_code/regular_hparams_medium2x.txt \
+       --config projects/dutch_real/pretrain_cfg.json
+
+
+#python -m src.new_code.pretrain --accelerator gpu --ddpstrategy auto --device $SLURM_GPUS_ON_NODE --config projects/dutch_real/pretrain_cfg.json
 

--- a/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
+++ b/src/llm/slurm_scripts/pretrain_multigpu_singlenode.sh
@@ -2,7 +2,7 @@
 
 #SBATCH --job-name=pretrain
 #SBATCH -p gpu
-#SBATCH --gpus-per-node=2
+#SBATCH --gpus-per-node=4
 #SBATCH -t 00:30:00
 #SBATCH -e %x-%j.err 
 #SBATCH -o %x-%j.out 
@@ -23,10 +23,10 @@ cd $REPO_DIR/src/llm/
 #Start training
 python -m src.new_code.pretrain \
        --accelerator gpu \
-       --ddpstrategy auto \
+       --ddpstrategy gloo \
        --device $SLURM_GPUS_ON_NODE \
        --batch 256 \
-       --hparams src/new_code/regular_hparams_medium2x.txt \
+       --hparams src/new_code/regular_hparams_large.txt \
        --config projects/dutch_real/pretrain_cfg.json
 
 

--- a/src/llm/src/new_code/pipeline.py
+++ b/src/llm/src/new_code/pipeline.py
@@ -180,8 +180,8 @@ def encode_documents(docs_with_counter, write_path_prefix, needed_ids, do_mlm, m
     person_document = PersonDocument(
       person_id=person_dict['person_id'],
       sentences=person_dict['sentence'],
-      abspos=[int(x) for x in person_dict['abspos']],
-      age=[int(x) for x in person_dict['age']],
+      abspos=[int(float(x)) for x in person_dict['abspos']],  
+      age=[int(float(x)) for x in person_dict['age']],
       segment=person_dict['segment'],
       background=Background(**person_dict['background']),
     )

--- a/src/llm/src/new_code/pipeline.py
+++ b/src/llm/src/new_code/pipeline.py
@@ -194,7 +194,7 @@ def encode_documents(docs_with_counter, write_path_prefix, needed_ids, do_mlm, m
     update_data_dict(data_dict, output, do_mlm)
     
   convert_to_numpy(data_dict)
-  write_path = f"{write_path_prefix}_{counter}.h5" 
+  write_path = f"{write_path_prefix}.h5" 
   write_to_hdf5(write_path, data_dict)
 
 def init_hdf5_datasets(h5f, data_dict, dtype='i4'):

--- a/src/llm/src/new_code/pipeline.py
+++ b/src/llm/src/new_code/pipeline.py
@@ -166,7 +166,7 @@ def convert_to_numpy(data_dict):
 
 def encode_documents(docs_with_counter, write_path_prefix, needed_ids, do_mlm, mlm):
   docs, counter = docs_with_counter
-  print("Starting to encode document {counter}",flush=True)
+  print(f"Starting to encode document {counter}",flush=True)
   data_dict = init_data_dict(do_mlm)
   for document in docs:
     person_dict = load_json_obj(document)
@@ -361,7 +361,7 @@ if __name__ == "__main__":
   logging.basicConfig(
     format='%(asctime)s %(name)s %(levelname)s: %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
-    level=logging.DEBUG
+    level=logging.INFO
   )
   CFG_PATH = sys.argv[1]
   cfg = read_json(CFG_PATH)

--- a/src/llm/src/new_code/pretrain.py
+++ b/src/llm/src/new_code/pretrain.py
@@ -101,7 +101,7 @@ def pretrain(cfg):
     accelerator='gpu',
     devices=1,
     logger=logger,
-    precision=16
+    precision="16-mixed"
   )
   val_dataset = CustomIterableDataset(
     mlm_path, 
@@ -120,6 +120,11 @@ def pretrain(cfg):
   trainer.fit(model, train_dataloader, val_dataloader)
   
 if __name__ == "__main__":
+  logging.basicConfig(
+    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+    level=logging.DEBUG
+  )
   torch.set_float32_matmul_precision("medium")
   CFG_PATH = sys.argv[1]
   print_now(CFG_PATH)

--- a/src/llm/src/new_code/pretrain.py
+++ b/src/llm/src/new_code/pretrain.py
@@ -68,16 +68,18 @@ def get_callbacks(ckpoint_dir, val_check_interval):
   ]
   return callbacks
 
-def pretrain(cfg, batch_size=None):
+def pretrain(cfg, batch_size=None, hparams=None):
   """Train the model with lightning trainer
 
   Args:
     cfg (dict): configuration dict from json config file
-    batch_size (int or None): batch size to use. If None, uses batch size specified in config.
+    batch_size (int, optional): batch size to use. If None, uses batch size specified in config.
+    hparams (str, optional): path to file with hyperparameters. If None, uses file specified in config.
   """
-  hparams_path = cfg['HPARAMS_PATH']#'src/new_code/regular_hparams.txt'
   ckpoint_dir = cfg['CHECKPOINT_DIR']
   mlm_path = cfg['MLM_PATH']
+
+  hparams_path = cfg['HPARAMS_PATH'] if not hparams else hparams
   hparams = read_hparams_from_file(hparams_path)
 
   num_val_items = cfg.get('NUM_VAL_ITEMS', 100000)
@@ -153,7 +155,8 @@ def parse_args():
     parser.add_argument("--accelerator", default="gpu", help="Choose an accelerator that connects a Lightning Trainer to arbitrary hardware (CPUs, GPUs, TPUs, HPUs, MPS, …)")
     parser.add_argument("--ddpstrategy", default="auto", help="pick ddp strategy (auto,gloo,mpi,...)")
     parser.add_argument("--devices", default=1, help=f"Number of devices")
-    parser.add_argument("--batch", default=None, help="Batch size to use. If None, uses batch size specified in the config file")
+    parser.add_argument("--batch", default=None, type=int, help="Batch size to use. If None, uses `batch` size specified in the config file")
+    parser.add_argument("--hparams", default=None, type=str, help="Path to hyperparameters file. If `None`, uses file specified in the config file")
     parser.add_argument("--config", required=True, help=f".json config",type=str)    
     return parser.parse_args()
 
@@ -164,6 +167,7 @@ if __name__ == "__main__":
     N_DEVICES=args.devices
     DDP_STRATEGY=args.ddpstrategy # strategy for pl.Trainer
     BATCH_SIZE=args.batch
+    HPARAMS=args.hparams
     CFG_PATH=args.config
 
     assert DDP_STRATEGY in ["auto", "ddp_mpi", "ddp", "gloo"]
@@ -177,4 +181,4 @@ if __name__ == "__main__":
 
     print_now(CFG_PATH)
     cfg = read_json(CFG_PATH)
-    pretrain(cfg, batch_size=BATCH_SIZE)
+    pretrain(cfg, batch_size=BATCH_SIZE, hparams=HPARAMS)

--- a/src/llm/src/new_code/pretrain.py
+++ b/src/llm/src/new_code/pretrain.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
   logging.basicConfig(
     format='%(asctime)s %(name)s %(levelname)s: %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S',
-    level=logging.DEBUG
+    level=logging.INFO
   )
   torch.set_float32_matmul_precision("medium")
   CFG_PATH = sys.argv[1]

--- a/src/llm/src/new_code/regular_hparams.txt
+++ b/src/llm/src/new_code/regular_hparams.txt
@@ -1,4 +1,4 @@
-vocab_size: 1938 #this one you should knwo in advance (fix later)
+vocab_size: 2918 #this one you should knwo in advance (fix later)
 max_epochs: 100
 train_split: 0.8
 batch_size: 10

--- a/src/llm/src/new_code/regular_hparams_large.txt
+++ b/src/llm/src/new_code/regular_hparams_large.txt
@@ -1,4 +1,4 @@
-vocab_size: 1938 #this one you should knwo in advance (fix later)
+vocab_size: 2918 #this one you should knwo in advance (fix later)
 max_epochs: 100
 train_split: 0.8
 batch_size: 10

--- a/src/llm/src/new_code/regular_hparams_medium2x.txt
+++ b/src/llm/src/new_code/regular_hparams_medium2x.txt
@@ -1,4 +1,4 @@
-vocab_size: 1938 #this one you should knwo in advance (fix later)
+vocab_size: 2918 #this one you should knwo in advance (fix later)
 max_epochs: 100
 train_split: 0.8
 batch_size: 10


### PR DESCRIPTION
Add code to run the LLM training pipeline on Snellius (using fake data).

These changes allow to run the following scripts 
- `create_json_seq.sh`
- `pipeline.sh`
- `pretrain.py`

Any other slurm scripts were not changed. They will need to be updated later.


#### Main changes
- argparsing for `pretrain.py` with several options: ddp satregy, batch size, N devices, path to config, path to hparams, accelerator
- the scripts in `src/llm/slurm_scripts` can be run with `bash` or with `source`; the latter is useful for interactive jobs. In the future, we can see to simplify the code there. (see `pretrain_multigpu_singlenode.sh` for an example)

#### Changes in configs
- changed vocab size from 1938 (real data) to 2918 (fake data). since we'll update the sequences of the real data soon, I leave this at 2918
- the `json` files for training now specify the path to the fake data. Again, leaving for now and opened issue for making this easier to maintain. #73

#### Minor changes
- type casting in `pipeline.py` b/c of fake data. this may be a bug in the fake data generation; made issue. #72 


#### Notes
Because we also started trying out how to run multi-gpu training in the same branch, this needs a bit of tidying. I will split the code into smaller PRs
- one for changes in the software stack: we changed to 2023, and python 3.11, and I need to discuss this with Dakota. This is done in #70 
- one for the other changes, and here we need to separate the config files for snellius and ossc. this should be done automatically eventually, but for now I will merge this with separate files.
