### PR TITLE
Deepwalk from parquet

### DIFF
--- a/pop2vec/graph/README.md
+++ b/pop2vec/graph/README.md
@@ -1,1 +1,34 @@
- 
+
+Documentation for graph data.
+
+### Generating random walks 
+
+The random walks that record the edge types are created with the code in the separate [repository](https://github.com/odissei-lifecourse/layered_walk).
+The code there creates a parquet dataset with the following file partitioning
+- `year=YYYY`
+- `iter_name=some_name`
+- `dry=0`
+- `/chunk-i.parquet`. In each iteration `i`, one walk is created for all nodes and all layers in the network.
+
+To generate the walks, the user needs to give a name to this particular iteration, which is recorded in the `iter_name` features. If iterations are repeated, existing walks are overwritten.
+
+If you create a new partitioning, make sure to use the same convention `partition=X`, and update the `ParquetWalk` dataclass described below. 
+
+### Training `deepwalk`
+
+The `deepwalk_dataset` uses the `ParquetWalk` class from `pop2vec.utils.parquet_walks`. This class handles the partitioning described 
+above and loads the walks for one epoch into a Dataframe.
+The code for `deepwalk` requires some command-line arguments as per the script `deepwalk.py`. 
+In addition, it requires the file `pop2vec.graph.config.data_config`, where the `deepwalk_data_config` dict defines data paths: 
+- Where to store the model and the embeddings 
+- The nesting structure of the parquet file described above -- this is important because the `ParquetWalk` class needs this information to query the entire set of walks. 
+- The name of the iteration that generated the walks
+
+Currently, the `deepwalk` script creates model and embeddings with the following naming convention: "`iter_name`_`year`". Particularly for embedddings, it might be worthwhile storing them in the same partitioned format as the walks.
+
+
+An example of a slurm script to run deepwalk is in `pop2vec.graph.slurm_scripts.run_deepwalk.py`.
+
+
+
+

--- a/pop2vec/graph/README.md
+++ b/pop2vec/graph/README.md
@@ -1,34 +1,32 @@
 
 Documentation for graph data.
 
-### Generating random walks 
+### Generating random walks
 
 The random walks that record the edge types are created with the code in the separate [repository](https://github.com/odissei-lifecourse/layered_walk).
 The code there creates a parquet dataset with the following file partitioning
 - `year=YYYY`
 - `iter_name=some_name`
+- `record_edge_type=X`
 - `dry=0`
-- `/chunk-i.parquet`. In each iteration `i`, one walk is created for all nodes and all layers in the network.
+- `/chunk-i.parquet`. In each iteration `i`, one walk is created for all nodes and all layers in the network. `X` is a boolean whether the walks have the edge types recorded or not.
 
 To generate the walks, the user needs to give a name to this particular iteration, which is recorded in the `iter_name` features. If iterations are repeated, existing walks are overwritten.
 
-If you create a new partitioning, make sure to use the same convention `partition=X`, and update the `ParquetWalk` dataclass described below. 
+If you create a new partitioning, make sure to use the same convention `partition=X`, and update the `ParquetWalk` dataclass described below.
 
 ### Training `deepwalk`
 
-The `deepwalk_dataset` uses the `ParquetWalk` class from `pop2vec.utils.parquet_walks`. This class handles the partitioning described 
+The `deepwalk_dataset` uses the `ParquetWalk` class from `pop2vec.utils.parquet_walks`. This class handles the partitioning described
 above and loads the walks for one epoch into a Dataframe.
-The code for `deepwalk` requires some command-line arguments as per the script `deepwalk.py`. 
-In addition, it requires the file `pop2vec.graph.config.data_config`, where the `deepwalk_data_config` dict defines data paths: 
-- Where to store the model and the embeddings 
-- The nesting structure of the parquet file described above -- this is important because the `ParquetWalk` class needs this information to query the entire set of walks. 
+The code for `deepwalk` requires some command-line arguments as per the script `deepwalk.py`.
+In addition, it requires the file `pop2vec.graph.config.data_config`, where the `deepwalk_data_config` dict defines data paths:
+- Where to store the model and the embeddings
+- The nesting structure of the parquet file described above -- this is important because the `ParquetWalk` class needs this information to query the entire set of walks.
 - The name of the iteration that generated the walks
 
-Currently, the `deepwalk` script creates model and embeddings with the following naming convention: "`iter_name`_`year`". Particularly for embedddings, it might be worthwhile storing them in the same partitioned format as the walks.
-
+When `deepwalk` is run, models and embeddings are stored in the same structure as the walks, starting from their respective roots. This means that
+- when deepwalk is run with repeated configurations, models and embeddings are overwritten
+- even if deepwalk is run with different hyperparameters, because not all hyperparameters are stored in the file name, models and embeddings may be overwritten.
 
 An example of a slurm script to run deepwalk is in `pop2vec.graph.slurm_scripts.run_deepwalk.py`.
-
-
-
-

--- a/pop2vec/graph/config/deepwalk_data_config.py
+++ b/pop2vec/graph/config/deepwalk_data_config.py
@@ -2,8 +2,10 @@ from pop2vec.utils.constants import DATA_ROOT
 
 data_config = {
     "parquet_root": DATA_ROOT + "graph/walks/",
-    "parquet_nests": "/*/*/*/*/*.parquet",
-    "walk_iteration_name": "walklen40_prob0.8",
+    "parquet_nests": "*/*/*/*/*.parquet",
+    "walk_iteration_name": "first_trial", 
+    #"walk_iteration_name": "walklen40_prob0.8",
     "embedding_dir": DATA_ROOT + "graph/embeddings/",
-    "model_dir": DATA_ROOT + "graph/mdoels/",
+    "model_dir": DATA_ROOT + "graph/models/",
+    "mapping_dir": DATA_ROOT + "graph/mappings/",
 }

--- a/pop2vec/graph/config/deepwalk_data_config.py
+++ b/pop2vec/graph/config/deepwalk_data_config.py
@@ -3,8 +3,8 @@ from pop2vec.utils.constants import DATA_ROOT
 
 data_config = {
     "parquet_root": DATA_ROOT + "graph/walks/",
-    "parquet_nests": "/*/*/*/*.parquet",
-    "walk_iteration_name": "walklen20_prob0.8",
+    "parquet_nests": "/*/*/*/*/*.parquet",
+    "walk_iteration_name": "walklen40_prob0.8",
     "embedding_dir": DATA_ROOT + "graph/embeddings/",
     "model_dir": DATA_ROOT + "graph/mdoels/",
 }

--- a/pop2vec/graph/config/deepwalk_data_config.py
+++ b/pop2vec/graph/config/deepwalk_data_config.py
@@ -1,0 +1,11 @@
+
+from pop2vec.utils.constants import DATA_ROOT
+
+data_config = {
+    "parquet_root": DATA_ROOT + "graph/walks/",
+    "parquet_nests": "/*/*/*/*.parquet",
+    "walk_iteration_name": "walklen20_prob0.8",
+    "embedding_dir": DATA_ROOT + "graph/embeddings/",
+    "model_dir": DATA_ROOT + "graph/mdoels/",
+    "year": 2010
+}

--- a/pop2vec/graph/config/deepwalk_data_config.py
+++ b/pop2vec/graph/config/deepwalk_data_config.py
@@ -7,5 +7,4 @@ data_config = {
     "walk_iteration_name": "walklen20_prob0.8",
     "embedding_dir": DATA_ROOT + "graph/embeddings/",
     "model_dir": DATA_ROOT + "graph/mdoels/",
-    "year": 2010
 }

--- a/pop2vec/graph/config/deepwalk_data_config.py
+++ b/pop2vec/graph/config/deepwalk_data_config.py
@@ -1,4 +1,3 @@
-
 from pop2vec.utils.constants import DATA_ROOT
 
 data_config = {

--- a/pop2vec/graph/slurm_scripts/run_deepwalk.py
+++ b/pop2vec/graph/slurm_scripts/run_deepwalk.py
@@ -10,16 +10,20 @@
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
+ndim=128
+window_size=10
+max_epochs=50
 
 source requirements/load_venv.sh
 
 python -m pop2vec.graph.src.deepwalk \
-        --dim 128 \
-        --window_size 10 \
-        --num_walks 1 \
-        --only_gpu \
-        --gpus 0 \
-        --print_loss \
-        --start_index 0 \
-        --max_epochs 50 \
-        --year 2016
+    --dim "$ndim" \
+    --window_size "$window_size" \
+    --num_walks 1 \
+    --only_gpu \
+    --gpus 0 \
+    --print_loss \
+    --start_index 0 \
+    --max_epochs "$max_epochs" \
+    --year 2016 \
+    --record_edge_type

--- a/pop2vec/graph/slurm_scripts/run_deepwalk.py
+++ b/pop2vec/graph/slurm_scripts/run_deepwalk.py
@@ -21,4 +21,5 @@ python -m pop2vec.graph.src.deepwalk \
         --gpus 0 \
         --print_loss \
         --start_index 0 \
-        --max_epochs 50
+        --max_epochs 50 \
+        --year 2016

--- a/pop2vec/graph/slurm_scripts/run_deepwalk.py
+++ b/pop2vec/graph/slurm_scripts/run_deepwalk.py
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+#SBATCH --job-name deepwalk
+#SBATCH --cpus-per-task=8
+#SBATCH --nodes=1
+#SBATCH --time=45:00:00
+#SBATCH -p comp_env
+#SBATCH --mem=50GB
+#SBATCH --nodelist=ossc9424vm4
+#SBATCH -e logs/%x-%j.err
+#SBATCH -o logs/%x-%j.out
+
+
+source requirements/load_venv.sh
+
+python -m pop2vec.graph.src.deepwalk \
+        --dim 128 \
+        --window_size 10 \
+        --num_walks 1 \
+        --only_gpu \
+        --gpus 0 \
+        --print_loss \
+        --start_index 0 \
+        --max_epochs 50

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -247,12 +247,14 @@ class DeepwalkTrainer:
         print("Saving model under name", self.model_save_file, flush=True)
         torch.save(self.emb_model, self.model_save_file)
 
-        if self.args.save_in_txt:
-            self.emb_model.save_embedding_txt(self.dataset, self.output_emb_file)
-        elif self.args.save_in_pt:
-            self.emb_model.save_embedding_pt(self.dataset, self.output_emb_file)
-        else:
-            self.emb_model.save_embedding(self.dataset, self.output_emb_file)
+        if self.args.save_in_txt or self.args.save_in_pt:
+            raise NotImplementedError
+
+        self.emb_model.save_embedding(
+                dataset=self.dataset,
+                file_name=self.output_emb_file,
+                parquet_root=self.parquet_root_embs)
+
 
 
 if __name__ == "__main__":
@@ -272,7 +274,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
             "--record_edge_type",
-            type=bool,
             action="store_true",
             help="Whether to use walks that record the edge type or not.")
     # output files
@@ -452,6 +453,6 @@ if __name__ == "__main__":
         if i % 10 == 0:
             trainer.emb_model.save_embedding(
                     dataset=trainer.dataset,
-                    file_name=temp_emb_filename,
+                    file_name=emb_file,
                     parquet_root=data_config["embedding_dir"],
                     record_epoch=True)

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -17,8 +17,6 @@ class DeepwalkTrainer:
         self.args = args
         self.dataset = DeepwalkDataset(
             walk_file=parquet_data_file,
-            map_file=args.map_file,
-            walk_length=args.walk_length,
             window_size=args.window_size,
             num_walks=args.num_walks,
             batch_size=args.batch_size,
@@ -45,7 +43,7 @@ class DeepwalkTrainer:
             self.emb_model = SkipGramModel(
                 emb_size=self.emb_size,
                 emb_dimension=self.args.dim,
-                walk_length=self.args.walk_length,
+                walk_length=self.dataset.walk_length,
                 window_size=self.args.window_size,
                 batch_size=self.args.batch_size,
                 only_cpu=self.args.only_cpu,
@@ -133,7 +131,7 @@ class DeepwalkTrainer:
         print("num batchs: %d in process [%d] GPU [%d]" % (num_batches, rank, gpu_id), flush=True)
         # number of positive node pairs in a sequence
         num_pos = int(
-            2 * self.args.walk_length * self.args.window_size - self.args.window_size * (self.args.window_size + 1)
+            2 * self.dataset.walk_length * self.args.window_size - self.args.window_size * (self.args.window_size + 1)
         )
 
         start = time.time()
@@ -176,7 +174,7 @@ class DeepwalkTrainer:
     def fast_train(self):
         """Fast train with dataloader with only gpu / only cpu."""
         # the number of postive node pairs of a node sequence
-        num_pos = 2 * self.args.walk_length * self.args.window_size - self.args.window_size * (
+        num_pos = 2 * self.dataset.walk_length * self.args.window_size - self.args.window_size * (
             self.args.window_size + 1
         )
         num_pos = int(num_pos)
@@ -336,12 +334,6 @@ if __name__ == "__main__":
         default=64,
         type=int,
         help="number of node sequences in each batch",
-    )
-    parser.add_argument(
-        "--walk_length",
-        default=40,
-        type=int,
-        help="number of nodes in a sequence",
     )
     parser.add_argument("--neg_weight", default=1.0, type=float, help="negative weight")
     parser.add_argument(

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -2,16 +2,16 @@ import argparse
 import os
 import random
 import time
+from pathlib import Path
 import numpy as np
 import torch
 import torch.multiprocessing as mp
-from pathlib import Path
-
 from torch.utils.data import DataLoader
+from pop2vec.graph.config.deepwalk_data_config import data_config
 from pop2vec.graph.src.deepwalk_dataset import DeepwalkDataset
 from pop2vec.graph.src.model import SkipGramModel
 from pop2vec.utils.parquet_walks import ParquetWalks
-from pop2vec.graph.config.deepwalk_data_config import data_config
+
 
 class DeepwalkTrainer:
     def __init__(self, args, parquet_data_file, model_save_file, output_emb_file, parquet_root_embs):
@@ -111,9 +111,8 @@ class DeepwalkTrainer:
             raise NotImplementedError
 
         self.emb_model.save_embedding(
-                dataset=self.dataset,
-                file_name=self.output_emb_file,
-                parquet_root=self.parquet_root_embs)
+            dataset=self.dataset, file_name=self.output_emb_file, parquet_root=self.parquet_root_embs
+        )
 
     def fast_train_sp(self, rank, gpu_id):
         """A subprocess for fast_train_mp."""
@@ -251,10 +250,8 @@ class DeepwalkTrainer:
             raise NotImplementedError
 
         self.emb_model.save_embedding(
-                dataset=self.dataset,
-                file_name=self.output_emb_file,
-                parquet_root=self.parquet_root_embs)
-
+            dataset=self.dataset, file_name=self.output_emb_file, parquet_root=self.parquet_root_embs
+        )
 
 
 if __name__ == "__main__":
@@ -273,9 +270,8 @@ if __name__ == "__main__":
         help="Walk iteration name to use.",
     )
     parser.add_argument(
-            "--record_edge_type",
-            action="store_true",
-            help="Whether to use walks that record the edge type or not.")
+        "--record_edge_type", action="store_true", help="Whether to use walks that record the edge type or not."
+    )
     # output files
     parser.add_argument(
         "--save_in_txt",
@@ -289,7 +285,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether save dat in pt format or npy",
     )
-
 
     parser.add_argument(
         "--map_file",
@@ -432,11 +427,11 @@ if __name__ == "__main__":
     emb_file = "embedding.parquet"
 
     data_file = ParquetWalks(
-            parquet_root = data_config["parquet_root"],
-            parquet_nests = data_config["parquet_nests"],
-            iter_name= data_config["walk_iteration_name"],
-            year=args.year,
-            record_edge_type=args.record_edge_type
+        parquet_root=data_config["parquet_root"],
+        parquet_nests=data_config["parquet_nests"],
+        iter_name=data_config["walk_iteration_name"],
+        year=args.year,
+        record_edge_type=args.record_edge_type,
     )
 
     model_save_file = data_config["model_dir"] + model_name + ".pth"
@@ -452,7 +447,8 @@ if __name__ == "__main__":
         # Every 10 epochs snapshot the embedding
         if i % 10 == 0:
             trainer.emb_model.save_embedding(
-                    dataset=trainer.dataset,
-                    file_name=emb_file,
-                    parquet_root=data_config["embedding_dir"],
-                    record_epoch=True)
+                dataset=trainer.dataset,
+                file_name=emb_file,
+                parquet_root=data_config["embedding_dir"],
+                record_epoch=True,
+            )

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -424,10 +424,11 @@ if __name__ == "__main__":
     max_epochs = args.max_epochs
 
     model_nesting_path = [
-            data_config["model_dir"],
-            f"year={args.year}",
-            f"iter_name={data_config['walk_iteration_name']}",
-            f"record_edge_type={int(args.record_edge_type)}"]
+        data_config["model_dir"],
+        f"year={args.year}",
+        f"iter_name={data_config['walk_iteration_name']}",
+        f"record_edge_type={int(args.record_edge_type)}",
+    ]
     model_save_file = Path(*model_nesting_path) / "model.pth"
     model_save_file.parent.mkdir(parents=True, exist_ok=True)
     model_save_file = str(model_save_file)
@@ -441,7 +442,6 @@ if __name__ == "__main__":
         year=args.year,
         record_edge_type=args.record_edge_type,
     )
-
 
     for i in range(start_index, max_epochs + 1):
         data_file.chunk_id = i

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -441,6 +441,7 @@ if __name__ == "__main__":
         iter_name=data_config["walk_iteration_name"],
         year=args.year,
         record_edge_type=args.record_edge_type,
+        mapping_dir=data_config["mapping_dir"]
     )
 
     for i in range(start_index, max_epochs + 1):

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -420,9 +420,9 @@ if __name__ == "__main__":
     start_index = args.start_index
     max_epochs = args.max_epochs
 
-    model_name = data_config["walk_iteration_name"] + "_" + str(data_config["year"])
+    model_name = data_config["walk_iteration_name"] + "_" + str(args.year)
 
-    emb_file = data_config["embedding_dir"] + model_name + ".emb" 
+    emb_file = data_config["embedding_dir"] + model_name + ".emb"
     emb_file = Path(emb_file)
     emb_root = str(emb_file.parent / emb_file.stem)
     emb_extension = emb_file.suffix

--- a/pop2vec/graph/src/deepwalk.py
+++ b/pop2vec/graph/src/deepwalk.py
@@ -423,7 +423,15 @@ if __name__ == "__main__":
     start_index = args.start_index
     max_epochs = args.max_epochs
 
-    model_name = data_config["walk_iteration_name"] + "_" + str(args.year)
+    model_nesting_path = [
+            data_config["model_dir"],
+            f"year={args.year}",
+            f"iter_name={data_config['walk_iteration_name']}",
+            f"record_edge_type={int(args.record_edge_type)}"]
+    model_save_file = Path(*model_nesting_path) / "model.pth"
+    model_save_file.parent.mkdir(parents=True, exist_ok=True)
+    model_save_file = str(model_save_file)
+
     emb_file = "embedding.parquet"
 
     data_file = ParquetWalks(
@@ -434,7 +442,6 @@ if __name__ == "__main__":
         record_edge_type=args.record_edge_type,
     )
 
-    model_save_file = data_config["model_dir"] + model_name + ".pth"
 
     for i in range(start_index, max_epochs + 1):
         data_file.chunk_id = i

--- a/pop2vec/graph/src/deepwalk_dataset.py
+++ b/pop2vec/graph/src/deepwalk_dataset.py
@@ -1,6 +1,8 @@
 import pandas as pd
-from torch.utils.data import Dataset, DataLoader
 import torch
+from torch.utils.data import DataLoader
+from torch.utils.data import Dataset
+
 
 class DeepwalkDataset(Dataset):
     def __init__(
@@ -12,10 +14,11 @@ class DeepwalkDataset(Dataset):
         num_walks,
         batch_size,
         negative=5,
-        gpus=[0],
+        gpus=None,
         fast_neg=True,
     ):
-
+        if gpus is None:
+            gpus = [0]
         self.walk_frame = walk_file.load_walks()
 
         self.walk_length = walk_length
@@ -27,22 +30,23 @@ class DeepwalkDataset(Dataset):
         self.fast_neg = fast_neg
 
     def __len__(self):
-        return self.walk_frame['SOURCE'].nunique()
+        return self.walk_frame["SOURCE"].nunique()
 
     def __getitem__(self, item):
         return torch.from_numpy(self.walk_frame.iloc[item].to_numpy())
 
-if __name__ == '__main__':
-    dataset = DeepwalkDataset("amazon_10_walks.csv",
-                              "",
-                              30,
-                              5,
-                              10,
-                              64,
-                              )
 
-    dataloader = DataLoader(dataset, batch_size=dataset.batch_size,
-                            shuffle=True, num_workers=dataset.num_procs)
+if __name__ == "__main__":
+    dataset = DeepwalkDataset(
+        "amazon_10_walks.csv",
+        "",
+        30,
+        5,
+        10,
+        64,
+    )
+
+    dataloader = DataLoader(dataset, batch_size=dataset.batch_size, shuffle=True, num_workers=dataset.num_procs)
 
     print(len(dataset))
     print(len(dataloader))

--- a/pop2vec/graph/src/deepwalk_dataset.py
+++ b/pop2vec/graph/src/deepwalk_dataset.py
@@ -17,7 +17,8 @@ class DeepwalkDataset(Dataset):
     ):
         if gpus is None:
             gpus = [0]
-        self.walk_frame = walk_file.load_walks()
+        self.walk_file = walk_file
+        self.walk_frame = self.walk_file.load_walks()
         self.walk_length = self.walk_frame.shape[1]
         self.window_size = window_size
         self.num_walks = num_walks

--- a/pop2vec/graph/src/deepwalk_dataset.py
+++ b/pop2vec/graph/src/deepwalk_dataset.py
@@ -16,7 +16,7 @@ class DeepwalkDataset(Dataset):
         fast_neg=True,
     ):
 
-        self.walk_frame = pd.read_csv(walk_file)
+        self.walk_frame = walk_file.load_walks()
 
         self.walk_length = walk_length
         self.window_size = window_size

--- a/pop2vec/graph/src/deepwalk_dataset.py
+++ b/pop2vec/graph/src/deepwalk_dataset.py
@@ -8,8 +8,6 @@ class DeepwalkDataset(Dataset):
     def __init__(
         self,
         walk_file,
-        map_file,
-        walk_length,
         window_size,
         num_walks,
         batch_size,
@@ -20,8 +18,7 @@ class DeepwalkDataset(Dataset):
         if gpus is None:
             gpus = [0]
         self.walk_frame = walk_file.load_walks()
-
-        self.walk_length = walk_length
+        self.walk_length = self.walk_frame.shape[1]
         self.window_size = window_size
         self.num_walks = num_walks
         self.batch_size = batch_size

--- a/pop2vec/graph/src/model.py
+++ b/pop2vec/graph/src/model.py
@@ -534,6 +534,7 @@ class SkipGramModel(nn.Module):
         n_rows, _ = embedding.shape
         mapped_indices = np.arange(n_rows)
         remapped_ids = dataset.walk_file.remap_ids(mapped_indices)
+        remapped_ids = np.expand_dims(remapped_ids, axis=1)
         embedding = np.hstack([remapped_ids, embedding])
 
         dataset.walk_file.save_embedding(

--- a/pop2vec/graph/src/model.py
+++ b/pop2vec/graph/src/model.py
@@ -1,19 +1,18 @@
 import pickle
 import random
-
 import numpy as np
 import torch
 import torch.multiprocessing as mp
-import torch.nn as nn
 import torch.nn.functional as F
+from torch import nn
 from torch.multiprocessing import Queue
 from torch.nn import init
 
 
 def init_emb2pos_index(walk_length, window_size, batch_size):
-    """select embedding of positive nodes from a batch of node embeddings
+    """Select embedding of positive nodes from a batch of node embeddings.
 
-    Return
+    Return:
     ------
     index_emb_posu torch.LongTensor : the indices of u_embeddings
     index_emb_posv torch.LongTensor : the indices of v_embeddings
@@ -44,10 +43,10 @@ def init_emb2pos_index(walk_length, window_size, batch_size):
 
 
 def init_emb2neg_index(walk_length, window_size, negative, batch_size):
-    """select embedding of negative nodes from a batch of node embeddings
-    for fast negative sampling
+    """Select embedding of negative nodes from a batch of node embeddings
+    for fast negative sampling.
 
-    Return
+    Return:
     ------
     index_emb_negu torch.LongTensor : the indices of u_embeddings
     index_emb_negv torch.LongTensor : the indices of v_embeddings
@@ -67,9 +66,7 @@ def init_emb2neg_index(walk_length, window_size, negative, batch_size):
                 if j < walk_length:
                     idx_list_u += [i + b * walk_length] * negative
 
-    idx_list_v = (
-        list(range(batch_size * walk_length)) * negative * window_size * 2
-    )
+    idx_list_v = list(range(batch_size * walk_length)) * negative * window_size * 2
     random.shuffle(idx_list_v)
     idx_list_v = idx_list_v[: len(idx_list_u)]
 
@@ -81,7 +78,7 @@ def init_emb2neg_index(walk_length, window_size, negative, batch_size):
 
 
 def init_weight(walk_length, window_size, batch_size):
-    """init context weight"""
+    """Init context weight."""
     weight = []
     for b in range(batch_size):
         for i in range(walk_length):
@@ -97,7 +94,7 @@ def init_weight(walk_length, window_size, batch_size):
 
 
 def init_empty_grad(emb_dimension, walk_length, batch_size):
-    """initialize gradient matrix"""
+    """Initialize gradient matrix."""
     grad_u = torch.zeros((batch_size * walk_length, emb_dimension))
     grad_v = torch.zeros((batch_size * walk_length, emb_dimension))
 
@@ -105,7 +102,7 @@ def init_empty_grad(emb_dimension, walk_length, batch_size):
 
 
 def adam(grad, state_sum, nodes, lr, device, only_gpu):
-    """calculate gradients according to adam"""
+    """Calculate gradients according to adam."""
     grad_sum = (grad * grad).mean(1)
     if not only_gpu:
         grad_sum = grad_sum.cpu()
@@ -120,7 +117,7 @@ def adam(grad, state_sum, nodes, lr, device, only_gpu):
 
 
 def async_update(num_threads, model, queue):
-    """asynchronous embedding update"""
+    """Asynchronous embedding update."""
     torch.set_num_threads(num_threads)
     while True:
         (grad_u, grad_v, grad_v_neg, nodes, neg_nodes) = queue.get()
@@ -130,13 +127,11 @@ def async_update(num_threads, model, queue):
             model.u_embeddings.weight.data.index_add_(0, nodes.view(-1), grad_u)
             model.v_embeddings.weight.data.index_add_(0, nodes.view(-1), grad_v)
             if neg_nodes is not None:
-                model.v_embeddings.weight.data.index_add_(
-                    0, neg_nodes.view(-1), grad_v_neg
-                )
+                model.v_embeddings.weight.data.index_add_(0, neg_nodes.view(-1), grad_v_neg)
 
 
 class SkipGramModel(nn.Module):
-    """Negative sampling based skip-gram"""
+    """Negative sampling based skip-gram."""
 
     def __init__(
         self,
@@ -159,7 +154,7 @@ class SkipGramModel(nn.Module):
         async_update,
         num_threads,
     ):
-        """initialize embedding on CPU
+        """Initialize embedding on CPU.
 
         Paremeters
         ----------
@@ -205,13 +200,9 @@ class SkipGramModel(nn.Module):
         self.device = torch.device("cpu")
 
         # content embedding
-        self.u_embeddings = nn.Embedding(
-            self.emb_size, self.emb_dimension, sparse=True
-        )
+        self.u_embeddings = nn.Embedding(self.emb_size, self.emb_dimension, sparse=True)
         # context embedding
-        self.v_embeddings = nn.Embedding(
-            self.emb_size, self.emb_dimension, sparse=True
-        )
+        self.v_embeddings = nn.Embedding(self.emb_size, self.emb_dimension, sparse=True)
         # initialze embedding
         initrange = 1.0 / self.emb_dimension
         init.uniform_(self.u_embeddings.weight.data, -initrange, initrange)
@@ -222,9 +213,7 @@ class SkipGramModel(nn.Module):
         self.lookup_table[0] = 0.0
         self.lookup_table[-1] = 1.0
         if self.record_loss:
-            self.logsigmoid_table = torch.log(
-                torch.sigmoid(torch.arange(-6.01, 6.01, 0.01))
-            )
+            self.logsigmoid_table = torch.log(torch.sigmoid(torch.arange(-6.01, 6.01, 0.01)))
             self.loss = []
 
         # indexes to select positive/negative node pairs from batch_walks
@@ -236,25 +225,19 @@ class SkipGramModel(nn.Module):
         )
 
         if self.use_context_weight:
-            self.context_weight = init_weight(
-                self.walk_length, self.window_size, self.batch_size
-            )
+            self.context_weight = init_weight(self.walk_length, self.window_size, self.batch_size)
 
         # adam
         self.state_sum_u = torch.zeros(self.emb_size)
         self.state_sum_v = torch.zeros(self.emb_size)
 
         # gradients of nodes in batch_walks
-        self.grad_u, self.grad_v = init_empty_grad(
-            self.emb_dimension, self.walk_length, self.batch_size
-        )
+        self.grad_u, self.grad_v = init_empty_grad(self.emb_dimension, self.walk_length, self.batch_size)
 
     def create_async_update(self):
         """Set up the async update subprocess."""
         self.async_q = Queue(1)
-        self.async_p = mp.Process(
-            target=async_update, args=(self.num_threads, self, self.async_q)
-        )
+        self.async_p = mp.Process(target=async_update, args=(self.num_threads, self, self.async_q))
         self.async_p.start()
 
     def finish_async_update(self):
@@ -263,14 +246,14 @@ class SkipGramModel(nn.Module):
         self.async_p.join()
 
     def share_memory(self):
-        """share the parameters across subprocesses"""
+        """Share the parameters across subprocesses."""
         self.u_embeddings.weight.share_memory_()
         self.v_embeddings.weight.share_memory_()
         self.state_sum_u.share_memory_()
         self.state_sum_v.share_memory_()
 
     def set_device(self, gpu_id):
-        """set gpu device"""
+        """Set gpu device."""
         self.device = torch.device("cuda:%d" % gpu_id)
         print("The device is", self.device)
         self.lookup_table = self.lookup_table.to(self.device)
@@ -286,7 +269,7 @@ class SkipGramModel(nn.Module):
             self.context_weight = self.context_weight.to(self.device)
 
     def all_to_device(self, gpu_id):
-        """move all of the parameters to a single GPU"""
+        """Move all of the parameters to a single GPU."""
         self.device = torch.device("cuda:%d" % gpu_id)
         self.set_device(gpu_id)
         self.u_embeddings = self.u_embeddings.cuda(gpu_id)
@@ -295,12 +278,12 @@ class SkipGramModel(nn.Module):
         self.state_sum_v = self.state_sum_v.to(self.device)
 
     def fast_sigmoid(self, score):
-        """do fast sigmoid by looking up in a pre-defined table"""
+        """Do fast sigmoid by looking up in a pre-defined table."""
         idx = torch.floor((score + 6.01) / 0.01).long()
         return self.lookup_table[idx]
 
     def fast_logsigmoid(self, score):
-        """do fast logsigmoid by looking up in a pre-defined table"""
+        """Do fast logsigmoid by looking up in a pre-defined table."""
         idx = torch.floor((score + 6.01) / 0.01).long()
         return self.logsigmoid_table[idx]
 
@@ -340,23 +323,13 @@ class SkipGramModel(nn.Module):
             nodes = nodes.to(self.device)
             if neg_nodes is not None:
                 neg_nodes = neg_nodes.to(self.device)
-        emb_u = (
-            self.u_embeddings(nodes)
-            .view(-1, self.emb_dimension)
-            .to(self.device)
-        )
-        emb_v = (
-            self.v_embeddings(nodes)
-            .view(-1, self.emb_dimension)
-            .to(self.device)
-        )
+        emb_u = self.u_embeddings(nodes).view(-1, self.emb_dimension).to(self.device)
+        emb_v = self.v_embeddings(nodes).view(-1, self.emb_dimension).to(self.device)
 
         ## Postive
         bs = len(batch_walks)
         if bs < self.batch_size:
-            index_emb_posu, index_emb_posv = init_emb2pos_index(
-                self.walk_length, self.window_size, bs
-            )
+            index_emb_posu, index_emb_posv = init_emb2pos_index(self.walk_length, self.window_size, bs)
             index_emb_posu = index_emb_posu.to(self.device)
             index_emb_posv = index_emb_posv.to(self.device)
         else:
@@ -377,21 +350,15 @@ class SkipGramModel(nn.Module):
 
         # [batch_size * num_pos, dim]
         if self.lap_norm > 0:
-            grad_u_pos = score * emb_pos_v + self.lap_norm * (
-                emb_pos_v - emb_pos_u
-            )
-            grad_v_pos = score * emb_pos_u + self.lap_norm * (
-                emb_pos_u - emb_pos_v
-            )
+            grad_u_pos = score * emb_pos_v + self.lap_norm * (emb_pos_v - emb_pos_u)
+            grad_v_pos = score * emb_pos_u + self.lap_norm * (emb_pos_u - emb_pos_v)
         else:
             grad_u_pos = score * emb_pos_v
             grad_v_pos = score * emb_pos_u
 
         if self.use_context_weight:
             if bs < self.batch_size:
-                context_weight = init_weight(
-                    self.walk_length, self.window_size, bs
-                ).to(self.device)
+                context_weight = init_weight(self.walk_length, self.window_size, bs).to(self.device)
             else:
                 context_weight = self.context_weight
             grad_u_pos *= context_weight
@@ -399,9 +366,7 @@ class SkipGramModel(nn.Module):
 
         # [batch_size * walk_length, dim]
         if bs < self.batch_size:
-            grad_u, grad_v = init_empty_grad(
-                self.emb_dimension, self.walk_length, bs
-            )
+            grad_u, grad_v = init_empty_grad(self.emb_dimension, self.walk_length, bs)
             grad_u = grad_u.to(self.device)
             grad_v = grad_v.to(self.device)
         else:
@@ -416,9 +381,7 @@ class SkipGramModel(nn.Module):
 
         ## Negative
         if bs < self.batch_size:
-            index_emb_negu, index_emb_negv = init_emb2neg_index(
-                self.walk_length, self.window_size, self.negative, bs
-            )
+            index_emb_negu, index_emb_negv = init_emb2neg_index(self.walk_length, self.window_size, self.negative, bs)
             index_emb_negu = index_emb_negu.to(self.device)
             index_emb_negv = index_emb_negv.to(self.device)
         else:
@@ -437,11 +400,7 @@ class SkipGramModel(nn.Module):
         # [batch_size * walk_length * negative, 1]
         score = -self.fast_sigmoid(neg_score).unsqueeze(1)
         if self.record_loss:
-            self.loss.append(
-                self.negative
-                * self.neg_weight
-                * torch.mean(self.fast_logsigmoid(-neg_score)).item()
-            )
+            self.loss.append(self.negative * self.neg_weight * torch.mean(self.fast_logsigmoid(-neg_score)).item())
 
         grad_u_neg = self.neg_weight * score * emb_neg_v
         grad_v_neg = self.neg_weight * score * emb_neg_u
@@ -454,12 +413,8 @@ class SkipGramModel(nn.Module):
         nodes = nodes.view(-1)
 
         # use adam optimizer
-        grad_u = adam(
-            grad_u, self.state_sum_u, nodes, lr, self.device, self.only_gpu
-        )
-        grad_v = adam(
-            grad_v, self.state_sum_v, nodes, lr, self.device, self.only_gpu
-        )
+        grad_u = adam(grad_u, self.state_sum_u, nodes, lr, self.device, self.only_gpu)
+        grad_v = adam(grad_v, self.state_sum_v, nodes, lr, self.device, self.only_gpu)
         if neg_nodes is not None:
             grad_v_neg = adam(
                 grad_v_neg,
@@ -491,10 +446,7 @@ class SkipGramModel(nn.Module):
             self.u_embeddings.weight.data.index_add_(0, nodes.view(-1), grad_u)
             self.v_embeddings.weight.data.index_add_(0, nodes.view(-1), grad_v)
             if neg_nodes is not None:
-                self.v_embeddings.weight.data.index_add_(
-                    0, neg_nodes.view(-1), grad_v_neg
-                )
-        return
+                self.v_embeddings.weight.data.index_add_(0, neg_nodes.view(-1), grad_v_neg)
 
     def forward(self, pos_u, pos_v, neg_v):
         """Do forward and backward. It is designed for future use."""
@@ -524,12 +476,10 @@ class SkipGramModel(nn.Module):
         """
         embedding = self.u_embeddings.weight.cpu().data.numpy()
         if self.norm:
-            embedding /= np.sqrt(np.sum(embedding * embedding, 1)).reshape(
-                -1, 1
-            )
+            embedding /= np.sqrt(np.sum(embedding * embedding, 1)).reshape(-1, 1)
 
         if dataset.walk_file.record_edge_type:
-            embedding = embedding[:-dataset.walk_file.n_edge_types, :]
+            embedding = embedding[: -dataset.walk_file.n_edge_types, :]
 
         n_rows, _ = embedding.shape
         mapped_indices = np.arange(n_rows)
@@ -538,10 +488,8 @@ class SkipGramModel(nn.Module):
         embedding = np.hstack([remapped_ids, embedding])
 
         dataset.walk_file.save_embedding(
-                embeddings=embedding,
-                parquet_root_out=parquet_root,
-                filename=file_name,
-                record_chunk=record_epoch)
+            embeddings=embedding, parquet_root_out=parquet_root, filename=file_name, record_chunk=record_epoch
+        )
         # NOTE: in principle, one could even use chunk_id here to store the model?
 
     def save_embedding_pt(self, dataset, file_name):
@@ -563,26 +511,20 @@ class SkipGramModel(nn.Module):
             embedding.index_add_(0, index, self.u_embeddings.weight.cpu().data)
 
             if self.norm:
-                embedding /= torch.sqrt(
-                    torch.sum(embedding.mul(embedding), 1) + 1e-6
-                ).unsqueeze(1)
+                embedding /= torch.sqrt(torch.sum(embedding.mul(embedding), 1) + 1e-6).unsqueeze(1)
             torch.save(embedding, file_name)
         except:
             self.save_embedding_pt_dgl_graph(dataset, file_name)
 
     def save_embedding_pt_dgl_graph(self, dataset, file_name):
-        """For ogb leaderboard"""
+        """For ogb leaderboard."""
         embedding = torch.zeros_like(self.u_embeddings.weight.cpu().data)
         valid_seeds = torch.LongTensor(dataset.valid_seeds)
-        valid_embedding = self.u_embeddings.weight.cpu().data.index_select(
-            0, valid_seeds
-        )
+        valid_embedding = self.u_embeddings.weight.cpu().data.index_select(0, valid_seeds)
         embedding.index_add_(0, valid_seeds, valid_embedding)
 
         if self.norm:
-            embedding /= torch.sqrt(
-                torch.sum(embedding.mul(embedding), 1) + 1e-6
-            ).unsqueeze(1)
+            embedding /= torch.sqrt(torch.sum(embedding.mul(embedding), 1) + 1e-6).unsqueeze(1)
 
         torch.save(embedding, file_name)
 
@@ -596,9 +538,7 @@ class SkipGramModel(nn.Module):
         """
         embedding = self.u_embeddings.weight.cpu().data.numpy()
         if self.norm:
-            embedding /= np.sqrt(np.sum(embedding * embedding, 1)).reshape(
-                -1, 1
-            )
+            embedding /= np.sqrt(np.sum(embedding * embedding, 1)).reshape(-1, 1)
         with open(file_name, "w") as f:
             f.write("%d %d\n" % (self.emb_size, self.emb_dimension))
             for wid in range(self.emb_size):

--- a/pop2vec/utils/constants.py
+++ b/pop2vec/utils/constants.py
@@ -3,16 +3,14 @@
 NOTE: socket.gethostname() does not work as expected on the Snellius login node.
 """
 
-import socket
 import os
+import socket
 from pathlib import Path
-
 
 host_name = socket.gethostname()
 os_user = os.environ["USER"]
-if "ossc" in host_name: 
-    #OSSC_ROOT = "/gpfs/ostor/ossc9424/homedir/" 
-     # TODO: this should just be os.environ["HOME"] 
+if "ossc" in host_name:
+    OSSC_ROOT = "/gpfs/ostor/ossc9424/homedir/" # legacy; should use os.environ["HOME"] instead
     DATA_ROOT = Path(os.environ["HOME"]) / Path("data/")
     DATA_ROOT = str(DATA_ROOT)
     LOCATION = "ossc"

--- a/pop2vec/utils/constants.py
+++ b/pop2vec/utils/constants.py
@@ -1,2 +1,29 @@
-OSSC_ROOT = "/gpfs/ostor/ossc9424/homedir/"
-DATA_ROOT = "/gpfs/ostor/ossc9424/homedir/data/"
+"""Define constants portable across systems.
+
+NOTE: socket.gethostname() does not work as expected on the Snellius login node.
+"""
+
+import socket
+import os
+from pathlib import Path
+
+
+host_name = socket.gethostname()
+os_user = os.environ["USER"]
+if "ossc" in host_name: 
+    #OSSC_ROOT = "/gpfs/ostor/ossc9424/homedir/" 
+     # TODO: this should just be os.environ["HOME"] 
+    DATA_ROOT = Path(os.environ["HOME"]) / Path("data/")
+    DATA_ROOT = str(DATA_ROOT)
+    LOCATION = "ossc"
+
+elif "snellius" in host_name:
+    DATA_ROOT = "/projects/0/prjs1019/data/"
+    LOCATION = "snellius"
+
+
+
+
+
+
+

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+import duckdb
+import pandas as pd
+
+
+def create_column_placeholders(cols) -> str: # suggested by Claude
+    """Return comma-separated columns to query."""
+    return ", ".join(cols)
+
+
+@dataclass
+class ParquetWalks:
+    """Container for loading dataframes of walks for deepwalk."""
+    parquet_path: str
+    year: str
+    iter_name: str
+    chunk_id = int | None
+
+    def load_walks(self) -> pd.DataFrame:
+        """Load random walks from parquet partitions."""
+        if self.chunk_id is None:
+            msg = "self.chunk_id is `None`, but `int` is required"
+            raise ValueError(msg)
+
+        con = duckdb.connect(":memory:")
+
+        column_query = """
+            SELECT column_name
+            FROM ( DESCRIBE TABLE '?' )
+        """
+        columns = con.execute(column_query, (self.parquet_path,)).fetchall()
+        source_col = ["SOURCE"]
+        step_cols = [col[0] for col in columns if "STEP" in col[0]]
+        cols_to_query = source_col + step_cols
+
+        # ruff: noqa: S608
+        main_query = f"""
+            SELECT {create_column_placeholders(cols_to_query)}
+            FROM parquet_scan(?, filename = true)
+            WHERE filename LIKE '%chunk-?.parquet'
+            AND dry = 0
+            AND year = ?
+            AND iter_name = ?
+        """
+        # ruff: enable: S608
+
+        query_args = (
+                *cols_to_query,
+                self.parquet_path,
+                self.year,
+                self.iter_name,
+                f"%chunk-{self.chunk_id}.parquet"
+                )
+        result = con.execute(main_query, query_args)
+        result_df = result.df()
+
+        n_unique = result_df["SOURCE"].nunique()
+        n_rows = result_df.shape[0]
+        if n_unique != n_rows:
+            msg = "Found duplicated SOURCE nodes"
+            raise RuntimeError(msg)
+
+        con.close()
+        return result_df

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -19,14 +19,30 @@ def create_column_placeholders(cols) -> str:  # suggested by Claude
 
 @dataclass
 class ParquetWalks:
-    """Container for handling walks.
+    """Container for handling walks stored in Parquet format.
 
-    Contains
-        - Metadata for file paths and walks 
-        - Method for loading dataframes of walks for deepwalk.
-        - Method for remapping and saving deepwalk embeddings.
+    This class provides functionality to load, process, and save random walks
+    and their associated embeddings from/to Parquet files. It handles file paths,
+    metadata, and operations related to the walks and embeddings.
+
+    Attributes:
+        parquet_root (str): Root directory for Parquet files.
+        parquet_nests (str): Nested directory structure for Parquet partitions.
+        year (int): Year of the walks to use.
+        iter_name (str): Name of the iteration or walk configuration.
+        record_edge_type (bool): Whether edge types are recorded in the walks.
+        mapping_dir (str): Directory containing ID mapping files.
+        chunk_id (int | None): ID of the current chunk, if applicable.
+        n_edge_types (int): Number of edge types (default is 5).
+
+    Methods:
+        remap_ids(mapped_indices): Remap 0-based indices of embeddings to original IDs.
+        save_embedding(embeddings, parquet_root_out, filename, record_chunk): Save embeddings to Parquet.
+        load_walks(): Load random walks from Parquet files.
+
+    The class is designed to work with partitioned Parquet data and provides
+    methods for handling ID remapping, embedding saving, and walk loading.
     """
-
     parquet_root: str
     parquet_nests: str  # TODO: could this not be inferred from all the partitions that are arguments below?
     year: int
@@ -134,6 +150,7 @@ class ParquetWalks:
 # this is only for development
 if __name__ == "__main__":
     parquet_dir = "/gpfs/ostor/ossc9424/homedir/data/graph/walks/"
+    mapping_dir = "/gpfs/ostor/ossc9424/homedir/data/graph/mappings/"
 
     data_file = ParquetWalks(
         parquet_root=parquet_dir,
@@ -141,6 +158,7 @@ if __name__ == "__main__":
         iter_name="walklen40_prob0.8",
         record_edge_type=False,
         year=2016,
+        mapping_dir=mapping_dir
     )
 
     data_file.chunk_id = 0

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -3,7 +3,7 @@ import duckdb
 import pandas as pd
 
 
-def create_column_placeholders(cols) -> str: # suggested by Claude
+def create_column_placeholders(cols) -> str:  # suggested by Claude
     """Return comma-separated columns to query."""
     return ", ".join(cols)
 
@@ -11,6 +11,7 @@ def create_column_placeholders(cols) -> str: # suggested by Claude
 @dataclass
 class ParquetWalks:
     """Container for loading dataframes of walks for deepwalk."""
+
     parquet_path: str
     year: str
     iter_name: str
@@ -44,13 +45,7 @@ class ParquetWalks:
         """
         # ruff: enable: S608
 
-        query_args = (
-                *cols_to_query,
-                self.parquet_path,
-                self.year,
-                self.iter_name,
-                f"%chunk-{self.chunk_id}.parquet"
-                )
+        query_args = (*cols_to_query, self.parquet_path, self.year, self.iter_name, f"%chunk-{self.chunk_id}.parquet")
         result = con.execute(main_query, query_args)
         result_df = result.df()
 

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -19,15 +19,23 @@ def create_column_placeholders(cols) -> str:  # suggested by Claude
 
 @dataclass
 class ParquetWalks:
-    """Container for loading dataframes of walks for deepwalk."""
+    """Container for handling walks.
+
+    Contains
+        - Metadata for file paths and walks 
+        - Method for loading dataframes of walks for deepwalk.
+        - Method for remapping and saving deepwalk embeddings.
+    """
 
     parquet_root: str
     parquet_nests: str  # TODO: could this not be inferred from all the partitions that are arguments below?
     year: int
     iter_name: str
     record_edge_type: bool
+    mapping_dir: str
     chunk_id: int | None = None
     n_edge_types: int = 5  # hard-coded number of edge types. should find way to determine automatically
+
 
     def remap_ids(self, mapped_indices):  # TODO: don't hard-code path here
         """Remap an array of mapped indices.
@@ -35,8 +43,8 @@ class ParquetWalks:
         From a list of mapped indices from 0 to len(mapped_indices)-1,
         return the ids corresponding to the indices.
         """
-        mapping_url = "/gpfs/ostor/ossc9424/homedir/data/graph/mappings/family_" + str(self.year) + ".pkl"
-        with Path(mapping_url).open("rb") as pkl_file:
+        mapping_url = Path(*[self.mapping_dir, "family_" + str(self.year)]).with_suffix(".pkl")
+        with mapping_url.open("rb") as pkl_file:
             person_mappings = dict(pickle.load(pkl_file))  # noqa: S301
 
         inverted_mappings = {value: key for key, value in person_mappings.items()}

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -22,14 +22,14 @@ class ParquetWalks:
     """Container for loading dataframes of walks for deepwalk."""
 
     parquet_root: str
-    parquet_nests: str # TODO: could this not be inferred from all the partitions that are arguments below?
+    parquet_nests: str  # TODO: could this not be inferred from all the partitions that are arguments below?
     year: int
     iter_name: str
     record_edge_type: bool
     chunk_id: int | None = None
-    n_edge_types: int = 5 # hard-coded number of edge types. should find way to determine automatically
+    n_edge_types: int = 5  # hard-coded number of edge types. should find way to determine automatically
 
-    def remap_ids(self, mapped_indices): # TODO: don't hard-code path here
+    def remap_ids(self, mapped_indices):  # TODO: don't hard-code path here
         """Remap an array of mapped indices.
 
         From a list of mapped indices from 0 to len(mapped_indices)-1,
@@ -37,19 +37,15 @@ class ParquetWalks:
         """
         mapping_url = "/gpfs/ostor/ossc9424/homedir/data/graph/mappings/family_" + str(self.year) + ".pkl"
         with Path(mapping_url).open("rb") as pkl_file:
-            person_mappings = dict(pickle.load(pkl_file)) # noqa: S301
-
+            person_mappings = dict(pickle.load(pkl_file))  # noqa: S301
 
         inverted_mappings = {value: key for key, value in person_mappings.items()}
         unmapped_ids = [inverted_mappings[idx] for idx in mapped_indices]
         return np.array(unmapped_ids)
 
-
-    def save_embedding(self,
-                       embeddings: np.ndarray,
-                       parquet_root_out: str,
-                       filename: str,
-                       record_chunk: bool=False) -> None:
+    def save_embedding(
+        self, embeddings: np.ndarray, parquet_root_out: str, filename: str, record_chunk: bool = False
+    ) -> None:
         """Save an array of embeddings to parquet.
 
         Args:
@@ -61,26 +57,22 @@ class ParquetWalks:
         Notes:
             Replicates the parquet nesting from the source data, but omits the lowest nest (`dry`).
         """
-        nests = OrderedDict([
-            ("year", self.year),
-            ("iter_name", self.iter_name),
-            ("record_edge_type", int(self.record_edge_type))
-            ])
+        nests = OrderedDict(
+            [("year", self.year), ("iter_name", self.iter_name), ("record_edge_type", int(self.record_edge_type))]
+        )
 
         if record_chunk:
             file_path = Path(filename)
             filename = file_path.stem + "_" + str(self.chunk_id) + file_path.suffix
 
         save_to_parquet(
-                data=embeddings,
-                id_col="rinpersoon_id",
-                prefix_data_cols="emb",
-                filename=filename,
-                parquet_nests=nests,
-                parquet_root=parquet_root_out
-                )
-
-
+            data=embeddings,
+            id_col="rinpersoon_id",
+            prefix_data_cols="emb",
+            filename=filename,
+            parquet_nests=nests,
+            parquet_root=parquet_root_out,
+        )
 
     def load_walks(self) -> pd.DataFrame:
         """Load random walks from parquet partitions."""
@@ -112,11 +104,7 @@ class ParquetWalks:
         """
         # ruff: enable: S608
 
-        query_args = (
-                parquet_path,
-                self.year,
-                int(self.record_edge_type),
-                self.iter_name)
+        query_args = (parquet_path, self.year, int(self.record_edge_type), self.iter_name)
 
         result = con.execute(main_query, query_args)
         result_df = result.df()
@@ -140,11 +128,12 @@ if __name__ == "__main__":
     parquet_dir = "/gpfs/ostor/ossc9424/homedir/data/graph/walks/"
 
     data_file = ParquetWalks(
-            parquet_root=parquet_dir,
-            parquet_nests= "*/*/*/*/*.parquet",
-            iter_name="walklen40_prob0.8",
-            record_edge_type=False,
-            year=2016)
+        parquet_root=parquet_dir,
+        parquet_nests="*/*/*/*/*.parquet",
+        iter_name="walklen40_prob0.8",
+        record_edge_type=False,
+        year=2016,
+    )
 
     data_file.chunk_id = 0
 

--- a/pop2vec/utils/parquet_walks.py
+++ b/pop2vec/utils/parquet_walks.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 import duckdb
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def create_column_placeholders(cols) -> str:  # suggested by Claude
@@ -13,9 +17,9 @@ class ParquetWalks:
     """Container for loading dataframes of walks for deepwalk."""
 
     parquet_path: str
-    year: str
+    year: int
     iter_name: str
-    chunk_id = int | None
+    chunk_id: int | None = None
 
     def load_walks(self) -> pd.DataFrame:
         """Load random walks from parquet partitions."""
@@ -57,3 +61,13 @@ class ParquetWalks:
 
         con.close()
         return result_df
+
+
+# this is only for development
+if __name__ == "__main__":
+    parquet_dir = "/gpfs/ostor/ossc9424/homedir/data/graph/walks/"
+
+    data_file = ParquetWalks(parquet_path=parquet_dir + "/*/*/*/*.parquet", iter_name="walklen15_prob0.8", year=2010)
+    data_file.chunk_id = 0
+
+    data_file.load_walks()

--- a/pop2vec/utils/save_to_parquet.py
+++ b/pop2vec/utils/save_to_parquet.py
@@ -1,0 +1,39 @@
+"""Taken from code for layered walk. Can be made more general."""
+
+from collections import OrderedDict
+from pathlib import Path
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+def save_to_parquet(
+    data: np.ndarray, id_col: str, prefix_data_cols: str, filename: str, parquet_nests: OrderedDict, parquet_root: str
+) -> None:
+    """Save an array to parquet with partitioning.
+
+    Args:
+        `data`: the data to save.
+        `id_col`: the name for the column with record identifiers.
+        `prefix_data_cols`: the prefix for the columns created from the remaining columns.
+        `filename`: the name of the parquet file.
+        `parquet_nests`: the nesting for parquet partitions. A key-value pair in this dictionary
+        gets converted into 'key=value'.
+        `parquet_root`: The root path to the parquet file.
+
+    Notes:
+        - The schema of the parquet file is determined by the `id_col` and the `prefix_data_cols`.
+    """
+    n_cols = data.shape[1]
+
+    data_cols = [f"{prefix_data_cols}_{i}" for i in range(n_cols - 1)]
+    col_names = [id_col, *data_cols]
+
+    table = pa.Table.from_arrays([data[:, i] for i in range(n_cols)], names=col_names)
+
+    partitions = [f"{key}={value}" for key, value in parquet_nests.items()]
+    save_dir = Path(parquet_root) / Path(*partitions)
+
+    save_dir.mkdir(parents=True, exist_ok=True)
+    save_path = save_dir / Path(filename)
+    pq.write_table(table, save_path)

--- a/pop2vec/utils/save_to_parquet.py
+++ b/pop2vec/utils/save_to_parquet.py
@@ -6,20 +6,26 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+# ruff: noqa: PLR0913
 
 def save_to_parquet(
-    data: np.ndarray, id_col: str, prefix_data_cols: str, filename: str, parquet_nests: OrderedDict, parquet_root: str
+        data: np.ndarray,
+        id_col: str,
+        prefix_data_cols: str,
+        filename: str,
+        parquet_nests: OrderedDict,
+        parquet_root: str
 ) -> None:
     """Save an array to parquet with partitioning.
 
     Args:
-        `data`: the data to save.
-        `id_col`: the name for the column with record identifiers.
-        `prefix_data_cols`: the prefix for the columns created from the remaining columns.
-        `filename`: the name of the parquet file.
-        `parquet_nests`: the nesting for parquet partitions. A key-value pair in this dictionary
+        data: the data to save.
+        id_col: the name for the column with record identifiers.
+        prefix_data_cols: the prefix for the columns created from the remaining columns.
+        filename: the name of the parquet file.
+        parquet_nests: the nesting for parquet partitions. A key-value pair in this dictionary
         gets converted into 'key=value'.
-        `parquet_root`: The root path to the parquet file.
+        parquet_root: The root path to the parquet file.
 
     Notes:
         - The schema of the parquet file is determined by the `id_col` and the `prefix_data_cols`.
@@ -29,7 +35,10 @@ def save_to_parquet(
     data_cols = [f"{prefix_data_cols}_{i}" for i in range(n_cols - 1)]
     col_names = [id_col, *data_cols]
 
-    table = pa.Table.from_arrays([data[:, i] for i in range(n_cols)], names=col_names)
+    table = pa.Table.from_arrays(
+            [pa.array(data[:, 0], type=pa.int64())] +
+            [data[:, i] for i in range(1, n_cols)],
+            names=col_names)
 
     partitions = [f"{key}={value}" for key, value in parquet_nests.items()]
     save_dir = Path(parquet_root) / Path(*partitions)

--- a/pop2vec/utils/save_to_parquet.py
+++ b/pop2vec/utils/save_to_parquet.py
@@ -8,13 +8,9 @@ import pyarrow.parquet as pq
 
 # ruff: noqa: PLR0913
 
+
 def save_to_parquet(
-        data: np.ndarray,
-        id_col: str,
-        prefix_data_cols: str,
-        filename: str,
-        parquet_nests: OrderedDict,
-        parquet_root: str
+    data: np.ndarray, id_col: str, prefix_data_cols: str, filename: str, parquet_nests: OrderedDict, parquet_root: str
 ) -> None:
     """Save an array to parquet with partitioning.
 
@@ -36,9 +32,8 @@ def save_to_parquet(
     col_names = [id_col, *data_cols]
 
     table = pa.Table.from_arrays(
-            [pa.array(data[:, 0], type=pa.int64())] +
-            [data[:, i] for i in range(1, n_cols)],
-            names=col_names)
+        [pa.array(data[:, 0], type=pa.int64())] + [data[:, i] for i in range(1, n_cols)], names=col_names
+    )
 
     partitions = [f"{key}={value}" for key, value in parquet_nests.items()]
     save_dir = Path(parquet_root) / Path(*partitions)


### PR DESCRIPTION
This pull request updates the deepwalk code to run with the new walk files, stored in parquet.
- It fixes #107 through a dataclass that returns the set of walks for a given epoch with `load_walks()`
- It determines walk length dynamically from shape of dataframe (number of columns) instead of command line argument
- adds the slurm script for running deepwalk
- separates some parameters related to data paths into a separate `config.py` file. The idea is that these parameters vary less with different runs than the command-line args. The thing I'm currently unsure about is the `walk_iteration_name`, which might be better stored as an argument in the arg parser
- in `pop2vec.utils.constants` I also started some logic to make it easier to run code on Snellius and on the OSSC. See #73


Still to do 
- [x] make some docs about running deepwalk and the data storage 
- [x] update the data paths of the fake data on Snellius to reflect what we have on the OSSC
- [x] run parquet data loader on ~~fake~~ real data 
- [x] save embeddings as parquet
