### PR TITLE
Better fake data

### DIFF
--- a/pop2vec/fake_data/generate_rinpersoon.py
+++ b/pop2vec/fake_data/generate_rinpersoon.py
@@ -1,0 +1,37 @@
+import csv
+import random
+import sys
+from pathlib import Path
+
+
+def write_ids_to_csv(ids, output_path):
+    """Writes the IDs to a CSV file with a header.
+
+    Args:
+        ids: A list of IDs to write.
+        output_path: The path to the output CSV file.
+    """
+    with Path(output_path).open("w", newline="") as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["RINPERSOON"])
+        for id_number in ids:
+            writer.writerow([id_number])
+
+
+def main():
+    """Main function to generate IDs and write them to a CSV file."""
+    len_argv = 2
+    if len(sys.argv) != len_argv:
+        msg = "Wrong number of arguments. Give 1 argument with the output path."
+        raise RuntimeError(msg)
+
+    output_path = sys.argv[1]
+    num_ids = 27_275_012
+    max_id = 999_999_999
+
+    ids = random.sample(range(1, max_id + 1), num_ids)
+    write_ids_to_csv(ids, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pop2vec/fake_data/generate_step2_data.py
+++ b/pop2vec/fake_data/generate_step2_data.py
@@ -1,33 +1,34 @@
 
-"""
-Create completely fake data for parquet files. This is for the new data structure and code as of 01/2025.
+"""Create completely fake data for parquet files. This is for the new data structure and code as of 01/2025.
 It supersedes most of the fake data generated in create_fake_data.py.
 """
 
 
 # TODO: make paths as arguments
 
-import pandas as pd
+import os
 import random
 import string
+from pathlib import Path
 import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import os
 from tqdm import tqdm
-from pathlib import Path
 
 # Constants
-MIN_ROWS = 100000#1_000_000
-MAX_ROWS = 500000#10_000_000
-GENESIS_DATE = pd.Timestamp('1971-12-30')
+MIN_ROWS = 10_000_000 #100000
+MAX_ROWS = 20_000_000 #10_000_000
+GENESIS_DATE = pd.Timestamp("1971-12-30")
 DATA_ROOT = "/projects/0/prjs1019/data/fake_data_v0"
-NROW_BACKGROUND = 10_000_000
+NROW_BACKGROUND = 20_000_000
+NROWS_PER_ID = 8
 
+# Yields at most MAX_ROWS / NROWS_PER_ID unique sequences
 
 def generate_random_string(length=5):
     """Generate a random string of fixed length."""
-    return ''.join(random.choices(string.ascii_lowercase, k=length))
+    return "".join(random.choices(string.ascii_lowercase, k=length))
 
 def generate_random_description(val):
     """Generate a random natural language description for a value."""
@@ -59,34 +60,32 @@ def generate_random_data(columns, num_rows, nrows_per_id=8):
     """
     global RANDOM_ID_POOL
 
-    print(f'generating {num_rows} rows with {len(columns)} columns')
-   
-    data = {} 
-    current_ids = np.random.choice(RANDOM_ID_POOL, size=num_rows//nrows_per_id, replace=False) 
-    
+    print(f"generating {num_rows} rows with {len(columns)} columns")
+
+    data = {}
+    current_ids = np.random.choice(RANDOM_ID_POOL, size=num_rows//nrows_per_id, replace=False)
+
     for col in columns:
-        if col == 'RINPERSOON':
+        if col == "RINPERSOON":
             draw_with_replacement = nrows_per_id > 1
             data[col] = np.random.choice(current_ids, size=num_rows, replace=draw_with_replacement)
 
-        elif col == 'daysSinceFirstEvent':
+        elif col == "daysSinceFirstEvent":
             data[col] = np.random.randint(0, 18_000, size=num_rows)  # Random days since genesis (roughly 50 years)
-        elif col == 'age':
+        elif col == "age":
             data[col] = np.random.randint(16, 100, size=num_rows)  # Age between 16 and 100
-        elif col == 'month':
+        elif col == "month":
             data[col] = np.random.randint(1, 13, size=num_rows)
-        elif col == 'year':
+        elif col == "year":
             data[col] = np.random.randint(1940, 2020, size=num_rows)
-        elif col == 'gender':
+        elif col == "gender":
             data[col] = np.random.randint(1, 3, size=num_rows)
-        elif col == 'municipality':
+        elif col == "municipality":
             data[col] = np.random.randint(1, 500, size=num_rows)
+        elif random.choice([True, False]):  # 50% probability for each
+            data[col] = np.random.randint(0, 1000, size=num_rows)  # Example numeric range
         else:
-            # Randomly decide if the column is numeric or categorical
-            if random.choice([True, False]):  # 50% probability for each
-                data[col] = np.random.randint(0, 1000, size=num_rows)  # Example numeric range
-            else:
-                data[col] = [generate_random_string(2) for _ in range(num_rows)]
+            data[col] = [generate_random_string(2) for _ in range(num_rows)]
     return pd.DataFrame(data)
 
 def create_parquet_and_metadata(df, file_name):
@@ -95,19 +94,19 @@ def create_parquet_and_metadata(df, file_name):
     parquet_path = Path(DATA_ROOT) / "step2" / f"{file_name}.parquet"
     table = pa.Table.from_pandas(df)
     pq.write_table(table, parquet_path)
-    
+
     # Generate metadata
     metadata = {
-        'Name': [],
-        'Type': [],
-        'ValueLabels': []
+        "Name": [],
+        "Type": [],
+        "ValueLabels": []
     }
     for col in df.columns:
-        if col in ['RINPERSOON', 'daysSinceFirstEvent', 'age']:
+        if col in ["RINPERSOON", "daysSinceFirstEvent", "age"]:
           continue
-        metadata['Name'].append(col)
-        col_type = 'Numeric' if pd.api.types.is_numeric_dtype(df[col]) else 'String'
-        metadata['Type'].append(col_type)
+        metadata["Name"].append(col)
+        col_type = "Numeric" if pd.api.types.is_numeric_dtype(df[col]) else "String"
+        metadata["Type"].append(col_type)
         x = random.randint(1, 10)
         unique_values = df[col].dropna().unique()
         if len(unique_values) > x:
@@ -115,18 +114,18 @@ def create_parquet_and_metadata(df, file_name):
         else:
             sampled_values = unique_values
         value_labels = {}
-        if 'background' not in file_name:
+        if "background" not in file_name:
           for val in sampled_values:
               # Generate a random natural language description
               description = generate_random_description(val)
               value_labels[val] = description
-        metadata['ValueLabels'].append(str(value_labels))
-    
+        metadata["ValueLabels"].append(str(value_labels))
+
     metadata_df = pd.DataFrame(metadata)
     meta_parquet_path = Path(DATA_ROOT) / "step2" / f"{file_name}_meta.parquet"
     meta_table = pa.Table.from_pandas(metadata_df)
     pq.write_table(meta_table, meta_parquet_path)
-    
+
     return parquet_path, meta_parquet_path
 
 def process_files(columns_dict):
@@ -135,24 +134,24 @@ def process_files(columns_dict):
             df = generate_random_data(columns, NROW_BACKGROUND, 1)
         else:
             num_rows = random.randint(MIN_ROWS, MAX_ROWS)
-            df = generate_random_data(columns, num_rows, 8)
-        
+            df = generate_random_data(columns, num_rows, NROWS_PER_ID)
+
         create_parquet_and_metadata(df, name)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     dir_path = Path(DATA_ROOT) / Path("empty_files")
     columns_dict = {}
-    RINPERSOONS_PATH = Path(DATA_ROOT) / 'fake_rinpersoons.csv'
+    RINPERSOONS_PATH = Path(DATA_ROOT) / "fake_rinpersoons.csv"
 
     for file_name in os.listdir(dir_path):
-        if file_name.endswith('.csv'):
-            file_path = dir_path / file_name 
+        if file_name.endswith(".csv"):
+            file_path = dir_path / file_name
             df = pd.read_csv(file_path, nrows=0)  # Read only the header
             columns = df.columns.tolist()
             columns_dict[os.path.splitext(file_name)[0]] = columns
-            
 
-    RANDOM_ID_POOL = pd.read_csv(RINPERSOONS_PATH)['RINPERSOON'].unique()
-    
+
+    RANDOM_ID_POOL = pd.read_csv(RINPERSOONS_PATH)["RINPERSOON"].unique()
+
     process_files(columns_dict)  # Execute the data generation and saving process
 

--- a/pop2vec/fake_data/generate_step2_data.py
+++ b/pop2vec/fake_data/generate_step2_data.py
@@ -1,0 +1,158 @@
+
+"""
+Create completely fake data for parquet files. This is for the new data structure and code as of 01/2025.
+It supersedes most of the fake data generated in create_fake_data.py.
+"""
+
+
+# TODO: make paths as arguments
+
+import pandas as pd
+import random
+import string
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import os
+from tqdm import tqdm
+from pathlib import Path
+
+# Constants
+MIN_ROWS = 100000#1_000_000
+MAX_ROWS = 500000#10_000_000
+GENESIS_DATE = pd.Timestamp('1971-12-30')
+DATA_ROOT = "/projects/0/prjs1019/data/fake_data_v0"
+NROW_BACKGROUND = 10_000_000
+
+
+def generate_random_string(length=5):
+    """Generate a random string of fixed length."""
+    return ''.join(random.choices(string.ascii_lowercase, k=length))
+
+def generate_random_description(val):
+    """Generate a random natural language description for a value."""
+    descriptions = [
+        f"Description for value {val}",
+        f"This value represents {val}",
+        f"Value {val} indicates a special case",
+        f"An example of {val}",
+        f"{val} is significant because...",
+        f"The value {val} corresponds to an important category",
+        f"Explanation for {val}",
+        f"The code {val} stands for...",
+        f"{val} is associated with certain characteristics",
+        f"Note about value {val}"
+    ]
+    return random.choice(descriptions)
+
+def generate_random_data(columns, num_rows, nrows_per_id=8):
+    """Generate random data for given columns and number of rows.
+
+    Creates a dataframe of categorical and continuous data. Identifiers are
+    drawn at random from a global pool of identifiers.
+
+    Arguments:
+        columns: names of columns to generate.
+        num_rows: number of rows to generate.
+        nrows_per_id: number of rows per id.
+
+    """
+    global RANDOM_ID_POOL
+
+    print(f'generating {num_rows} rows with {len(columns)} columns')
+   
+    data = {} 
+    current_ids = np.random.choice(RANDOM_ID_POOL, size=num_rows//nrows_per_id, replace=False) 
+    
+    for col in columns:
+        if col == 'RINPERSOON':
+            draw_with_replacement = nrows_per_id > 1
+            data[col] = np.random.choice(current_ids, size=num_rows, replace=draw_with_replacement)
+
+        elif col == 'daysSinceFirstEvent':
+            data[col] = np.random.randint(0, 18_000, size=num_rows)  # Random days since genesis (roughly 50 years)
+        elif col == 'age':
+            data[col] = np.random.randint(16, 100, size=num_rows)  # Age between 16 and 100
+        elif col == 'month':
+            data[col] = np.random.randint(1, 13, size=num_rows)
+        elif col == 'year':
+            data[col] = np.random.randint(1940, 2020, size=num_rows)
+        elif col == 'gender':
+            data[col] = np.random.randint(1, 3, size=num_rows)
+        elif col == 'municipality':
+            data[col] = np.random.randint(1, 500, size=num_rows)
+        else:
+            # Randomly decide if the column is numeric or categorical
+            if random.choice([True, False]):  # 50% probability for each
+                data[col] = np.random.randint(0, 1000, size=num_rows)  # Example numeric range
+            else:
+                data[col] = [generate_random_string(2) for _ in range(num_rows)]
+    return pd.DataFrame(data)
+
+def create_parquet_and_metadata(df, file_name):
+    """Save DataFrame as Parquet and create corresponding metadata Parquet."""
+    # Save data to Parquet
+    parquet_path = Path(DATA_ROOT) / "step2" / f"{file_name}.parquet"
+    table = pa.Table.from_pandas(df)
+    pq.write_table(table, parquet_path)
+    
+    # Generate metadata
+    metadata = {
+        'Name': [],
+        'Type': [],
+        'ValueLabels': []
+    }
+    for col in df.columns:
+        if col in ['RINPERSOON', 'daysSinceFirstEvent', 'age']:
+          continue
+        metadata['Name'].append(col)
+        col_type = 'Numeric' if pd.api.types.is_numeric_dtype(df[col]) else 'String'
+        metadata['Type'].append(col_type)
+        x = random.randint(1, 10)
+        unique_values = df[col].dropna().unique()
+        if len(unique_values) > x:
+            sampled_values = np.random.choice(unique_values, x, replace=False)
+        else:
+            sampled_values = unique_values
+        value_labels = {}
+        if 'background' not in file_name:
+          for val in sampled_values:
+              # Generate a random natural language description
+              description = generate_random_description(val)
+              value_labels[val] = description
+        metadata['ValueLabels'].append(str(value_labels))
+    
+    metadata_df = pd.DataFrame(metadata)
+    meta_parquet_path = Path(DATA_ROOT) / "step2" / f"{file_name}_meta.parquet"
+    meta_table = pa.Table.from_pandas(metadata_df)
+    pq.write_table(meta_table, meta_parquet_path)
+    
+    return parquet_path, meta_parquet_path
+
+def process_files(columns_dict):
+    for name, columns in tqdm(columns_dict.items()):
+        if "background" in name:
+            df = generate_random_data(columns, NROW_BACKGROUND, 1)
+        else:
+            num_rows = random.randint(MIN_ROWS, MAX_ROWS)
+            df = generate_random_data(columns, num_rows, 8)
+        
+        create_parquet_and_metadata(df, name)
+
+if __name__ == '__main__':
+    dir_path = Path(DATA_ROOT) / Path("empty_files")
+    columns_dict = {}
+    RINPERSOONS_PATH = Path(DATA_ROOT) / 'fake_rinpersoons.csv'
+
+    for file_name in os.listdir(dir_path):
+        if file_name.endswith('.csv'):
+            file_path = dir_path / file_name 
+            df = pd.read_csv(file_path, nrows=0)  # Read only the header
+            columns = df.columns.tolist()
+            columns_dict[os.path.splitext(file_name)[0]] = columns
+            
+
+    RANDOM_ID_POOL = pd.read_csv(RINPERSOONS_PATH)['RINPERSOON'].unique()
+    
+    process_files(columns_dict)  # Execute the data generation and saving process
+

--- a/pop2vec/fake_data/slurm_scripts/create_fake_parquets.sh
+++ b/pop2vec/fake_data/slurm_scripts/create_fake_parquets.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+#SBATCH --job-name=fake_parquet
+#SBATCH --ntasks 1
+#SBATCH --cpus-per-task 10 
+#SBATCH --nodes=1
+#SBATCH --time=30:00
+#SBATCH --mem=50G
+#SBATCH -p rome
+#SBATCH -e logs/%x-%j.err
+#SBATCH -o logs/%x-%j.out
+
+# NOTE: this currently supersedes the scripts `create_fake_data.sh`.
+
+echo "job started"
+
+source requirements/load_venv.sh
+
+python -m pop2vec.fake_data.generate_rinpersoon /projects/0/prjs1019/data/fake_data_v0/fake_rinpersoons.csv
+
+python -m pop2vec.fake_data.generate_step2_data
+
+
+
+
+
+
+
+

--- a/pop2vec/llm/src/new_code/create_person_dict.py
+++ b/pop2vec/llm/src/new_code/create_person_dict.py
@@ -78,9 +78,9 @@ class CreatePersonDict:
             str: Background file path.
         """
         background_file_path = [fp for fp in file_paths if "background" in os.path.basename(fp)]
-        assert len(background_file_path) == 1, (
-            f"Unique Background file not found.\n" f"found background files list: {background_file_path}"
-        )
+        if len(background_file_path) != 1:
+            msg = f"Unique background file not found. Instead, found this list: {background_file_path}"
+            raise RuntimeError(msg)
         return background_file_path[0]
 
     def _process_background_data(self):

--- a/pop2vec/utils/merge_hdf5.py
+++ b/pop2vec/utils/merge_hdf5.py
@@ -1,20 +1,26 @@
+import os
+from pathlib import Path
+import h5py
+import numpy as np
+
+
 def merge_hdf5_files(input_files, output_file, chunk_size=1000):
     if os.path.exists(output_file):
         os.remove(output_file)
 
     # Open all input files
-    h5_files = [h5py.File(f, 'r') for f in input_files]
+    h5_files = [h5py.File(f, "r") for f in input_files]
 
     # Open the output file
-    with h5py.File(output_file, 'w') as h5f_out:
+    with h5py.File(output_file, "w") as h5f_out:
         # Initialize datasets in the output file
         for key in h5_files[0].keys():
             shape = list(h5_files[0][key].shape)
             shape[0] = None  # Unlimited size along the first axis
             maxshape = tuple(shape)
             dtype = h5_files[0][key].dtype
-            if key == 'sequence_id':
-                dtype = h5py.special_dtype(vlen=str)
+            if key == "sequence_id":
+                dtype = np.int64
             h5f_out.create_dataset(
                 key,
                 shape=(0,) + h5_files[0][key].shape[1:],


### PR DESCRIPTION
Integrate data generation and make data pipeline work from step2 to step5

- integrate files for creating fake rinpersoon IDS and fake data 
- avoid duplicated IDs in the background file
- automatically merge hdf5 files at the end of step5, and remove the chunks
- move the merge_hdf5 function into `utils/`

### I ran this pipeline this morning, with `MIN_ROWS` = 10Mio and `MAX_ROWS` = 20 Mio.
- creating fake data takes 30minutes and 100GB
- running preprocess, create_life_seq and pipeline takes
	- preprocess takes: 1h
	- create_life_seq: 50min
	- pipeline: 30min
- in this instance, I got HH records for 2Mio unique households, 2Mio unique for INPATAB and SPOLISBUS, each with around 8 rows per ID. This is about 1 order of magnitude smaller than what we expect for the full-count data. More on this in #128 
While we do have 20 Mio records in `people.parquet`, 15Mio of them have sequence=`[]` and age = `[]`. 


I suggest we merge this and then continue with the other steps for the milestone.


