### PR TITLE
fixes mean pooling issue

### DIFF
--- a/pop2vec/llm/projects/dutch_real/infer_cfg_test_snellius.json
+++ b/pop2vec/llm/projects/dutch_real/infer_cfg_test_snellius.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "pop2vec/llm/src/new_code/regular_hparams_small.txt",
   "CHECKPOINT_PATH": "/projects/0/prjs1019/data/fake_models_v0/model-epoch=02-step=495-val_loss=0.00.ckpt",
-  "TOKENIZED_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/chunk_64_no_mlm.h5",
-  "EMB_WRITE_PATH": "/projects/0/prjs1019/data/llm/embeddings/emb_test.h5",
+  "TOKENIZED_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/no_mlm_encoded_test.h5",
+  "EMB_WRITE_PATH": "/projects/0/prjs1019/data/fake_embs/jan_29_fixed_test2.h5",
   "BATCH_SIZE": 2048
 }

--- a/pop2vec/llm/slurm_scripts/infer_snellius_test.sh
+++ b/pop2vec/llm/slurm_scripts/infer_snellius_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+#SBATCH --job-name=infer_small
+#SBATCH --ntasks-per-node=1
+#SBATCH --nodes=1
+#SBATCH --time=30:00
+#SBATCH --mem=1G
+#SBATCH -p gpu
+#SBATCH --gpus 1
+#SBATCH -e logs/%x-%j.err
+#SBATCH -o logs/%x-%j.out
+
+#declare PREFIX="/gpfs/ostor/ossc9424/homedir/"
+
+#export CUDA_VISIBLE_DEVICES=0
+
+echo "job started"
+
+source requirements/load_venv.sh
+
+date
+time python -m pop2vec.llm.src.new_code.infer_embedding pop2vec/llm/projects/dutch_real/infer_cfg_test_snellius.json
+
+echo "job ended successfully"


### PR DESCRIPTION
I found a bug where we mean pool over all the tokens' output embeddings in the end instead of mean pooling over only the real tokens' output embeddings. We should ignore the padding tokens' embeddings while doing the mean pooling.   

The Life2Vec model's code zeros out all the padding token embeddings in all the intermediate transformer blocks but skips doing that for the final transformer block. The 4 lines starting from here: https://github.com/odissei-lifecourse/life-sequencing-dutch/blob/4bd6bfd7f006f7383e3ce2a120a4647394d0bb64/pop2vec/llm/src/transformer/transformer.py#L72

 Therefore, The padding tokens do not have all 0 valued embeddings.

We are essentially mean pooling over some real embeddings and a lot of garbage embeddings of the same padding token for all the people. This PR fixes the issue by summing only the relevant token embeddings and dividing by the relevant token count.