### PR TITLE
use default row groups for parallel pipeline

### DIFF
--- a/pop2vec/llm/slurm_scripts/pipeline.sh
+++ b/pop2vec/llm/slurm_scripts/pipeline.sh
@@ -2,11 +2,11 @@
 #
 #SBATCH --job-name=pipeline
 #SBATCH --ntasks 1
-#SBATCH --cpus-per-task 72 
+#SBATCH --cpus-per-task 18 
 #SBATCH --nodes=1
 #SBATCH --time=02:30:00
-#SBATCH --mem=40G
-#SBATCH -p rome
+#SBATCH --mem=200G
+#SBATCH -p fat_rome
 #SBATCH -e logs/%x-%j.err
 #SBATCH -o logs/%x-%j.out
 
@@ -14,7 +14,7 @@ echo "job started"
 
 source requirements/load_venv.sh
 #srun python -m pop2vec.llm.src.new_code.pipeline pop2vec/llm/projects/dutch_real/pipeline_cfg.json
-srun python -m pop2vec.llm.src.new_code.pipeline pop2vec/llm/projects/dutch_real/pipeline_no_mlm_cfg.json
+srun python -m pop2vec.llm.src.new_code.pipeline pop2vec/llm/projects/dutch_real/pipeline_cfg.json
 
 
 

--- a/pop2vec/llm/src/new_code/create_person_dict.py
+++ b/pop2vec/llm/src/new_code/create_person_dict.py
@@ -242,5 +242,5 @@ class CreatePersonDict:
         people_df = people_df[[self.primary_key, "background", "sentence", "abspos", "age", "segment"]]
 
         # Write to Parquet file
-        people_df.to_parquet(write_path, index=False, row_group_size=len(people_df) // 65)
+        people_df.to_parquet(write_path, index=False)
         logging.info(f"Data written to {write_path}")


### PR DESCRIPTION
This fixes some things discussed in #139 .

Using the default row group size and just parallelizing over row groups seems to be the easiest solution.

Note
- I changed existing files on the OSSC and on Snellius (`people.parquet`) to the default row groups by loading the entire file into duckdb and the writing it to disk without specifying the row group number / size 
- I successfully ran this code on the OSSC and on Snellius in parallel
- I use os.sched_getaffinity instead of os.cpu_count as this is the recommended way on slurm 
