### PR TITLE
Event masking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   hooks:
     # Run the linter.
     - id: ruff
-      args: [ --fix ]
+      args: [ --fix,  --config=pyproject.toml] # https://github.com/astral-sh/ruff-pre-commit/issues/54
     # Run the formatter.
     - id: ruff-format
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/notebooks/masking.ipynb
+++ b/notebooks/masking.ipynb
@@ -1,0 +1,801 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c856d1ab-7a99-4a9c-a128-7ac95c456322",
+   "metadata": {},
+   "source": [
+    "### Illustrating token masking \n",
+    "\n",
+    "This notebook has a small example of events and illustrates how masking works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "83d7aa9d-41a4-4abd-be72-7b6fe5d2c335",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/flavio/repositories/projects/odissei-life2vec/life-sequencing-dutch/.venv/lib/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from typing import Tuple\n",
+    "from pop2vec.llm.src.new_code.custom_vocab import CustomVocabulary\n",
+    "from pop2vec.llm.src.data_new.types import PersonDocument, Background\n",
+    "from pop2vec.llm.src.tasks.mlm import MLM\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06120013-eba5-498e-82a4-11b8313229d5",
+   "metadata": {},
+   "source": [
+    "#### First, we create some input data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "a4d6d68e-c188-427a-be48-1c23ac385cde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [\n",
+    "    {\n",
+    "        \"person_id\": 1, \n",
+    "        \"segment\": [2, 4, 6, 7, 8],\n",
+    "        \"age\": [18, 24, 29, 33, 56],\n",
+    "        \"abspos\": [200, 404, 500, 600, 805],\n",
+    "        \"background\": {\"birth_year\": \"year_99.0\", \"birth_month\": \"month_12.0\", \"gender\": \"gender_2\", \"origin\": \"municipality_54.0\"},\n",
+    "        \"sentence\": [ \n",
+    "            [\"educSim_2.0\"], \n",
+    "            [\"_4_D\"], \n",
+    "            [\"contractType2_1.0\", \"sicknessInsurance2_1.0\", \"wage_50.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance3_1.0\", \"wage_10.0\"],\n",
+    "            [\"contractType1_1.0\", \"sicknessInsurance1_1.0\", \"wage_20.0\"],\n",
+    "        ]\n",
+    "    },\n",
+    "    {\n",
+    "        \"person_id\": 2, \n",
+    "        \"segment\": [6, 3, 10, 10, 10, 11, 12, 13, 14, 15],\n",
+    "        \"age\": [19, 22, 40, 42, 55, 80, 99, 101, 204, 206],\n",
+    "        \"abspos\": [99, 103, 501, 708, 890, 899, 901, 910, 915, 930],\n",
+    "        \"background\": {\"birth_year\": \"year_95.0\", \"birth_month\": \"month_5.0\", \"gender\": \"gender_1\", \"origin\": \"municipality_15.0\"},\n",
+    "        \"sentence\": [\n",
+    "            [\"educSim_1.0\"], \n",
+    "            [\"contractType2_1.0\", \"_4_D\"],\n",
+    "            [\"contractType2_1.0\", \"wage_50.0\", \"sicknessInsurance2_2.0\"] ,\n",
+    "            [\"contractType2_1.0\", \"sicknessInsurance1_1.0\", \"wage_50.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "            [\"contractType4_1.0\", \"sicknessInsurance2_0.0\", \"wage_10.0\"],\n",
+    "        ]\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "person_df = pd.DataFrame(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f949d363-2aae-49ef-b1e0-7e4f9a7c966a",
+   "metadata": {},
+   "source": [
+    "We need to create the vocabulary from these data (normally done from files that define the sequence data above)\n",
+    "\n",
+    "The vocabulary should look as follows:\n",
+    "\n",
+    "```txt\n",
+    "TOKEN,CATEGORY,ID\n",
+    "[PAD],GENERAL,0\n",
+    "[CLS],GENERAL,1\n",
+    "[SEP],GENERAL,2\n",
+    "[MASK],GENERAL,3\n",
+    "[UNK],GENERAL,4\n",
+    "gender_1,BACKGROUND,5\n",
+    "gender_2,BACKGROUND,6\n",
+    "gender_MISSING,BACKGROUND,7\n",
+    "year_1958,background_shuffled_year,8\n",
+    "year_1962,background_shuffled_year,9\n",
+    "year_2003,background_shuffled_year,10\n",
+    "year_1961,background_shuffled_year,11\n",
+    "year_1952,background_shuffled_year,12\n",
+    "year_1971,background_shuffled_year,13\n",
+    "year_1991,background_shuffled_year,14\n",
+    "year_2016,background_shuffled_year,15\n",
+    "year_1965,background_shuffled_year,16\n",
+    "year_2008,background_shuffled_year,17\n",
+    "year_1963,background_shuffled_year,18\n",
+    "```\n",
+    "\n",
+    "- category refers to `filename_colname`; token consists of `colname_content`\n",
+    "- abspos is an increasing sequence of integers\n",
+    "- age, segment and abspos are constant for all tokens in the same event (?)\n",
+    "- sentence\n",
+    "\t- array of arrays. each array is an event. each event has string tokens such as `['INPAINV3400P_93', 'INPEMEZ_Others', 'INPKKGEM_Others', 'INPPH770UP_93']`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "cf3a00ba-2014-45d4-a0b8-11867f1ec6b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_vocab(person_list):\n",
+    "    sentence_tokens = set()\n",
+    "    for person in person_list:\n",
+    "        tokens = [token for event in person[\"sentence\"] for token in event]\n",
+    "        sentence_tokens |= set(tokens) \n",
+    "\n",
+    "    background = [person[\"background\"] for person in person_list]\n",
+    "    background_tokens = pd.DataFrame(background)\n",
+    "\n",
+    "    general_tokens = [\"[PAD]\", \"[CLS]\", \"[SEP]\", \"[MASK]\", \"[UNK]\"]\n",
+    "    vocab = []\n",
+    "    \n",
+    "    for token in general_tokens:\n",
+    "        item = {\"TOKEN\": token, \"CATEGORY\": \"GENERAL\"}\n",
+    "        vocab.append(item)\n",
+    "    \n",
+    "    \n",
+    "    for token in sentence_tokens:\n",
+    "        item = {\"TOKEN\": token, \"CATEGORY\": \"income_file\"}\n",
+    "        vocab.append(item)\n",
+    "    \n",
+    "    for col in background_tokens.columns:\n",
+    "        for x in background_tokens[col].unique():\n",
+    "            item = {\"TOKEN\": x, \"CATEGORY\": \"background\"}\n",
+    "            vocab.append(item)\n",
+    "    \n",
+    "    vocab_df = pd.DataFrame(vocab)\n",
+    "    vocab_df[\"ID\"] = vocab_df.index\n",
+    "    return vocab_df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "e8d70797-a9e4-4fb0-a968-90d6cce8b7a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['[PAD]', '[CLS]', '[SEP]', '[MASK]', '[UNK]']"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vocab_df = get_vocab(data)\n",
+    "myvocab = CustomVocabulary(name=\"test\", data_files=[\"a.csv\", \"b.csv\"])\n",
+    "myvocab.vocab_df = vocab_df\n",
+    "myvocab.general_tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "e91067e5-9564-4c19-89d7-021086ef32fc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TOKEN</th>\n",
+       "      <th>CATEGORY</th>\n",
+       "      <th>ID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[PAD]</td>\n",
+       "      <td>GENERAL</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>[CLS]</td>\n",
+       "      <td>GENERAL</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>[SEP]</td>\n",
+       "      <td>GENERAL</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>[MASK]</td>\n",
+       "      <td>GENERAL</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>[UNK]</td>\n",
+       "      <td>GENERAL</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>sicknessInsurance2_2.0</td>\n",
+       "      <td>income_file</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>sicknessInsurance2_1.0</td>\n",
+       "      <td>income_file</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>sicknessInsurance3_1.0</td>\n",
+       "      <td>income_file</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>contractType4_1.0</td>\n",
+       "      <td>income_file</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>educSim_1.0</td>\n",
+       "      <td>income_file</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    TOKEN     CATEGORY  ID\n",
+       "0                   [PAD]      GENERAL   0\n",
+       "1                   [CLS]      GENERAL   1\n",
+       "2                   [SEP]      GENERAL   2\n",
+       "3                  [MASK]      GENERAL   3\n",
+       "4                   [UNK]      GENERAL   4\n",
+       "5  sicknessInsurance2_2.0  income_file   5\n",
+       "6  sicknessInsurance2_1.0  income_file   6\n",
+       "7  sicknessInsurance3_1.0  income_file   7\n",
+       "8       contractType4_1.0  income_file   8\n",
+       "9             educSim_1.0  income_file   9"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vocab_df.head(10) # masked tokens have value 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "c10d9e2b-0758-4846-94e7-fa6c05a850ea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>person_id</th>\n",
+       "      <th>segment</th>\n",
+       "      <th>age</th>\n",
+       "      <th>abspos</th>\n",
+       "      <th>background</th>\n",
+       "      <th>sentence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>[2, 4, 6, 7, 8]</td>\n",
+       "      <td>[18, 24, 29, 33, 56]</td>\n",
+       "      <td>[200, 404, 500, 600, 805]</td>\n",
+       "      <td>{'birth_year': 'year_99.0', 'birth_month': 'mo...</td>\n",
+       "      <td>[[educSim_2.0], [_4_D], [contractType2_1.0, si...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>[6, 3, 10, 10, 10, 11, 12, 13, 14, 15]</td>\n",
+       "      <td>[19, 22, 40, 42, 55, 80, 99, 101, 204, 206]</td>\n",
+       "      <td>[99, 103, 501, 708, 890, 899, 901, 910, 915, 930]</td>\n",
+       "      <td>{'birth_year': 'year_95.0', 'birth_month': 'mo...</td>\n",
+       "      <td>[[educSim_1.0], [contractType2_1.0, _4_D], [co...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   person_id                                 segment  \\\n",
+       "0          1                         [2, 4, 6, 7, 8]   \n",
+       "1          2  [6, 3, 10, 10, 10, 11, 12, 13, 14, 15]   \n",
+       "\n",
+       "                                           age  \\\n",
+       "0                         [18, 24, 29, 33, 56]   \n",
+       "1  [19, 22, 40, 42, 55, 80, 99, 101, 204, 206]   \n",
+       "\n",
+       "                                              abspos  \\\n",
+       "0                          [200, 404, 500, 600, 805]   \n",
+       "1  [99, 103, 501, 708, 890, 899, 901, 910, 915, 930]   \n",
+       "\n",
+       "                                          background  \\\n",
+       "0  {'birth_year': 'year_99.0', 'birth_month': 'mo...   \n",
+       "1  {'birth_year': 'year_95.0', 'birth_month': 'mo...   \n",
+       "\n",
+       "                                            sentence  \n",
+       "0  [[educSim_2.0], [_4_D], [contractType2_1.0, si...  \n",
+       "1  [[educSim_1.0], [contractType2_1.0, _4_D], [co...  "
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "person_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44989c21-b070-49fe-bc85-832f8882cf0a",
+   "metadata": {},
+   "source": [
+    "### Create a person document\n",
+    "\n",
+    "Similar to the data that are passed into `pipeline.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "1e36074c-82ca-4aa5-90d2-36e9cd108a71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = list(person_df.itertuples())[0]\n",
+    "person_id = getattr(row, \"person_id\")\n",
+    "sentences = row.sentence\n",
+    "person_document = PersonDocument(\n",
+    "    person_id=person_id,\n",
+    "    sentences=sentences, # note: diff to original code (??)\n",
+    "    abspos=[int(float(x)) for x in row.abspos],\n",
+    "    age=[int(float(x)) for x in row.age],\n",
+    "    segment=[int(x) for x in row.segment],\n",
+    "    background=Background(**row.background),\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "617f1521-941b-444c-98af-45395c65ac40",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sentences)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ac8f63a-18ba-4301-80e5-d5c040976524",
+   "metadata": {},
+   "source": [
+    "#### Set the MLM encoder and run it\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "3ebb9124-fb81-4c3e-8cb1-21cd459f2867",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlm = MLM(\"mytest\", max_length = 16, masking=\"random\")\n",
+    "mlm.set_vocabulary(myvocab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "7a2ca69b-0339-40db-bf9b-13d3f276fbd6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MLM(name='mytest', max_length=16, no_sep=False, p_sequence_timecut=0.0, p_sequence_resample=0.0, p_sequence_abspos_noise=0.0, p_sequence_hide_background=0.0, p_sentence_drop_tokens=0.0, shuffle_within_sentences=True, mask_ratio=0.3, smart_masking=False, masking='random')"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mlm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "7068e536-6d8f-4fcb-b632-6e06f0a638c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = mlm.encode_document(person_document, do_mlm=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "0aa7fcda-2123-4013-ab42-2dd5267d7c0a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MLM(name='mytest', max_length=16, no_sep=False, p_sequence_timecut=0.0, p_sequence_resample=0.0, p_sequence_abspos_noise=0.0, p_sequence_hide_background=0.0, p_sentence_drop_tokens=0.0, shuffle_within_sentences=True, mask_ratio=0.3, smart_masking=False, masking='random')"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mlm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "392072f7-b425-44b8-8ba1-0bbb714cc17b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output is None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d05a5e9b-5248-44d9-ba77-8164618c18d4",
+   "metadata": {},
+   "source": [
+    "#### The main result are the `input_ids`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "b89df147-9bd8-446e-b2b0-ded5d8192b25",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(4, 16)"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(len(output.input_ids))\n",
+    "output.input_ids[0][:40] # what are these input ids? -> they are the model predictors\n",
+    "output.input_ids.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf17896f-a4aa-4709-bcb0-5cb644668a65",
+   "metadata": {},
+   "source": [
+    "For each sample, `input_ids` is an array of `[4, sequence_length]`\n",
+    "- first row are the tokens - the masked or non-masked sequence\n",
+    "- the second row is the absolute position (calender time?)\n",
+    "- the third row is the age\n",
+    "- the fourth row is the segment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "82d90e9e-e46f-4852-b8f8-c26a4e3e4dfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.original_sequence[10]\n",
+    "# the difference between the original sequence and the input_ids is that \n",
+    "# the input_ids has the target tokens removed "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "a131f3b3-c61f-462b-9d6b-afb698b8c035",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 4, 12,  6,  7])"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.target_pos # this is the index in the sequence that is masked"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "67fa2a67-1289-4d86-a903-f3802831d831",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.target_pos.min()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "830d1b7f-6de4-480c-a9d2-07498744d7d6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([19., 18.,  8.,  7.])"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.target_tokens # this is the value of the masked tokens to be predicted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "23219f8e-9316-46d5-af9f-65951a0bb56b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_target_position(idx, encoded_document):\n",
+    "    print(f\"position {idx} in the original sequence with value {encoded_document.original_sequence[idx]} is a target token\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "fdee9683-f586-4d17-b9be-8971dc1adbcd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "position 4 in the original sequence with value 19 is a target token\n",
+      "position 12 in the original sequence with value 18 is a target token\n",
+      "position 6 in the original sequence with value 8 is a target token\n",
+      "position 7 in the original sequence with value 7 is a target token\n"
+     ]
+    }
+   ],
+   "source": [
+    "for idx in output.target_pos:\n",
+    "    print_target_position(idx, output)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "a9ef50d3-7e0a-4012-b736-de60c9b96c1d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.input_ids[0, 1]\n",
+    "output.input_ids[1,1] # this is the absolute position of the masked token \n",
+    "output.input_ids[2,1] # this is the age of the masked token\n",
+    "output.input_ids[3,1] # this is the segment of the masked token\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24e82982-132d-4834-9961-dd7555b3ecf5",
+   "metadata": {},
+   "source": [
+    "Checking a single token\n",
+    "- background tokens have 0s for age, abspos etc - makes sense"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a7e6e51c-2097-47ab-aa08-6177717006e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_token = output.input_ids[:, 10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "83db368e-c139-4bd3-b9bd-bb80b170fca2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([  5., 805.,  56.,   8.])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_token"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pop2vec/llm/projects/dutch_real/pipeline_cfg.json
+++ b/pop2vec/llm/projects/dutch_real/pipeline_cfg.json
@@ -1,6 +1,6 @@
 {
   "DATA_PATH": "/projects/0/prjs1019/data/fake_data_v0/step3/",
-  "SEQUENCE_PATH": "/projects/0/prjs1019/data/fake_data_v0/step4/people.parquet",
+  "SEQUENCE_PATH": "/projects/0/prjs1019/data/fake_data_v0/step4/people_dryrun.parquet",
   "VOCAB_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/vocab_v0.csv",
   "ENCODING_WRITE_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/",
   "DO_MLM": true,
@@ -9,5 +9,6 @@
   "TIME_RANGE_END": 16438,
   "MAX_SEQ_LEN": 512,
   "LOAD_VOCAB": false,
-  "PARALLEL": true
+  "PARALLEL": true,
+  "MASKING": "random"
  }

--- a/pop2vec/llm/projects/dutch_real/pretrain_cfg_small.json
+++ b/pop2vec/llm/projects/dutch_real/pretrain_cfg_small.json
@@ -1,7 +1,7 @@
 {
   "HPARAMS_PATH": "pop2vec/llm/src/new_code/regular_hparams_small.txt",
   "CHECKPOINT_DIR": "/projects/0/prjs1019/data/fake_models_v0/",   
-  "MLM_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/chunk_64.h5",
+  "MLM_PATH": "/projects/0/prjs1019/data/fake_data_v0/step5/encoding=mlm/masking=event/encoded_dryrun.h5",
   "MAX_EPOCHS": 30,
   "BATCH_SIZE": 256,
   "NUM_VAL_ITEMS": 5000

--- a/pop2vec/llm/src/tasks/sentence_masking.py
+++ b/pop2vec/llm/src/tasks/sentence_masking.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+def find_sentences_to_mask(
+    token_sequence: NDArray[np.int_],
+    sep_token: int,
+    mask_frac: float,
+    ignore_tokens: list[int],
+) -> tuple[NDArray[np.int_], NDArray[np.int_]]:
+    """Determine random set of sentences to be masked.
+
+    Args:
+        token_sequence (np.ndarray): the sequence of tokens to mask. The last
+            token needs to be a `sep_token`. The start of the first sentence
+            is identified by the first token that is not a member of `ignore_tokens`.
+        sep_token (int): the identifier of the SEP token.
+        mask_frac (float): the fraction of tokens to be masked. Must be between 0 and 1.
+        ignore_tokens (list): token ids to be ignored at the start of the sequence.
+            Concerns the CLS token at the start of the sequence, and possibly others.
+
+    Returns:
+        A tuple of numpy arrays.
+        - The first entry are the start/end positions of sentence:
+            The position of the `sep_tokens` and the last `ignore_token`
+            before the first sentence starts. Note these are the tokens
+            that *surround* any given sentence.
+        - The second are the sentences selected for masking.
+
+    Raises:
+        - a ValueError if the `mask_frac` is out of bounds
+        - a RuntimeError if the sequence is not ended with a `sep_token`.
+
+    Notes:
+        The function always returns at least one sentence to mask. This means
+        that the effect masking fraction of tokens masked is larger than specified
+        through `mask_frac`. For larger sequences with many tokens, however, this
+        is unlikely to happen.
+    """
+    if mask_frac <= 0 or mask_frac >= 1:
+        msg = "mask frac needs to be strictly between 0 and 1."
+        raise ValueError(msg)
+
+    if not isinstance(token_sequence, np.ndarray):
+        raise TypeError
+
+    if token_sequence[-1] != sep_token:
+        msg = "Last token needs to be a `sep_token`."
+        raise RuntimeError(msg)
+
+    rng = np.random.default_rng()
+    n_tokens = len(token_sequence)
+    ignore_tokens_arr = np.asarray(ignore_tokens)
+
+    idx_sentence_sep = np.nonzero(token_sequence == sep_token)[0]
+    idx_first_relevant_token = np.min(
+        np.nonzero(~np.isin(token_sequence, ignore_tokens_arr) & ~np.isin(token_sequence, sep_token))
+    )
+
+    # If there are any sep tokens before the first relevant tokens, we ignore them
+    idx_sentence_sep = idx_sentence_sep[idx_sentence_sep > idx_first_relevant_token]
+    sentence_ids = np.arange(len(idx_sentence_sep))
+    rng.shuffle(sentence_ids)
+
+    sentence_lengths = np.diff(np.hstack((idx_first_relevant_token - 1, idx_sentence_sep)))
+    # deduct one to get the number of relevant tokens in each sentence
+    sentence_lengths -= 1
+
+    lengths_shuffled = sentence_lengths[sentence_ids]
+    lengths_cumsum = np.cumsum(lengths_shuffled)
+    sentences_to_mask = lengths_cumsum / n_tokens <= mask_frac
+
+    sentence_starts_and_ends = np.hstack((idx_first_relevant_token - 1, idx_sentence_sep))
+    return sentence_starts_and_ends, np.sort(sentence_ids[sentences_to_mask])
+
+
+def mask_tokens_in_sentences(  # noqa: PLR0913
+    token_sequence: NDArray[np.int_],
+    sentence_starts_and_ends: NDArray[np.int_],
+    sentences_to_mask: NDArray[np.int_],
+    mask_id: int,
+    len_target_array: int,
+    fill_val_target_idx: int,
+) -> tuple[NDArray[np.int_], NDArray[np.int_], NDArray[np.int_]]:
+    """Mask all tokens belonging to the same sentences.
+
+    Args:
+        token_sequence (np.ndarray): sequence of tokens to be masked.
+        sentence_starts_and_ends (np.ndarray): the indices of non-sentence tokens surrounding sentences.
+            These are SEP tokens, and any general token before the first sentence. Masking a whole
+            sentence will mask all tokens *between* two surrounding, non-sentence tokens.
+        sentences_to_mask (np.ndarray): indices of sentences, among all sentences, to be masked.
+        mask_id (int): the token ID for the mask.
+        len_target_array (int): length of the array returned for the indices and true
+            values of the masked tokens. Keeping this constant across samples
+            is important for the training algorithm.
+        fill_val_target_idx (int): the value with which to pad the array of
+            target tokens.
+
+    Returns: A tuple of np.ndarrays:
+    - The first entry is the masked sequence
+    - The second entry are the indices of the masked tokens
+    - The third entry are the true values of the masked tokens
+    """
+    if len(sentences_to_mask) == 0:  # TODO: this will also have to be fixed
+        masked_sequence = token_sequence
+        target_idx = np.array([])
+        target_tokens = np.array([])
+
+    else:
+        masking_idx_start = sentence_starts_and_ends[sentences_to_mask]
+        masking_idx_stop = sentence_starts_and_ends[sentences_to_mask + 1]
+        token_indices = np.arange(len(token_sequence))
+
+        mask = (token_indices[:, None] > masking_idx_start) & (token_indices[:, None] < masking_idx_stop)
+        mask = mask.any(axis=1)
+
+        masked_sequence = token_sequence.copy()
+        masked_sequence[mask] = mask_id
+        target_tokens = token_sequence[mask]
+        target_idx = np.nonzero(mask)[0]
+
+    target_idx = _pad_array(target_idx, len_target_array, fill_val_target_idx)
+    target_tokens = _pad_array(target_tokens, len_target_array, 0)
+
+    return masked_sequence, target_idx, target_tokens
+
+
+def _pad_array(arr: NDArray, length: int, fill_value: int) -> NDArray:
+    """Right-pad an array up to length with fill_value."""
+    if len(arr) > length:
+        raise ValueError
+
+    out = np.full(shape=length, fill_value=fill_value)
+    out[: len(arr)] = arr.copy()
+    return out

--- a/pop2vec/llm/tests/test_sentence_masking.py
+++ b/pop2vec/llm/tests/test_sentence_masking.py
@@ -1,0 +1,204 @@
+import numpy as np
+import pytest
+from pop2vec.llm.src.tasks.sentence_masking import find_sentences_to_mask
+from pop2vec.llm.src.tasks.sentence_masking import mask_tokens_in_sentences
+
+MASK_ID = 99
+LEN_TARGET_ARRAY = 10
+FILL_VAL_TARGET_IDX = 511
+
+
+def test_find_sentences_basic():
+    token_sequence = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 5])
+    sep_token = 5
+    mask_frac = 0.5
+    ignore_tokens = [1]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    assert isinstance(starts_and_ends, np.ndarray)
+    assert isinstance(sentences_to_mask, np.ndarray)
+    assert len(sentences_to_mask) > 0
+
+
+def test_find_sentences_invalid_inputs():
+    token_sequence = np.array([1, 2, 3, 4, 5])
+    sep_token = 5
+    ignore_tokens = [1]
+
+    with pytest.raises(ValueError):
+        find_sentences_to_mask(token_sequence, sep_token, 0, ignore_tokens)
+
+    with pytest.raises(ValueError):
+        find_sentences_to_mask(token_sequence, sep_token, 1, ignore_tokens)
+
+    with pytest.raises(TypeError):
+        find_sentences_to_mask(list(token_sequence), sep_token, 0.4, ignore_tokens)  # pyright: ignore[reportArgumentType]
+
+    token_sequence = np.array([1, 2, 3, 4, 5, 7])
+    with pytest.raises(RuntimeError):
+        find_sentences_to_mask(token_sequence, sep_token, 0.4, ignore_tokens)
+
+
+def test_find_sentences_all_sentences_masked():
+    token_sequence = np.array([1, 2, 3, 5, 6, 7, 5, 8, 9, 5])
+    sep_token = 5
+    mask_frac = 0.99
+    ignore_tokens = [1]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    n_sentences = np.nonzero(token_sequence == sep_token)[0].shape[0]
+    assert len(sentences_to_mask) == n_sentences, "Does not mask all sentences"
+
+
+def test_find_sentences_no_sentences_masked():
+    token_sequence = np.array([1, 2, 3, 5, 6, 7, 5, 8, 9, 5])
+    sep_token = 5
+    mask_frac = 0.1
+    ignore_tokens = [1]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    assert len(sentences_to_mask) == 0, "no sentence should be masked"
+
+
+def test_find_sentences_ignore_tokens():
+    token_sequence = np.array([1, 2, 3, 4, 5, 6, 7, 5, 8, 9, 5])
+    sep_token = 5
+    mask_frac = 0.5
+    ignore_tokens = [1, 2, 3]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    assert starts_and_ends[0] == len(ignore_tokens) - 1, "does not ignore tokens correctly"
+
+
+def test_find_sentences_edge_cases():
+    # single sentence
+    token_sequence = np.array([1, 2, 3, 4, 5])
+    sep_token = 5
+    mask_frac = 0.5
+    ignore_tokens = [1]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    assert len(sentences_to_mask) == 0, "no sentences should be masked"
+
+    # ignore token followed by sep token
+    token_sequence = np.array([1, 5, 2, 3, 4, 5, 6, 7, 5])
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+    expected_starts_and_ends = np.array([1, 5, 8])
+    assert np.all(starts_and_ends == expected_starts_and_ends)
+
+    # ignore sep token followed by ignore token
+    token_sequence = np.array([5, 1, 2, 3, 4, 5, 6, 7, 5])
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+    expected_starts_and_ends = np.array([1, 5, 8])
+    assert np.all(starts_and_ends == expected_starts_and_ends)
+
+
+def test_find_sentences_output_types():
+    token_sequence = np.array([1, 2, 3, 4, 5, 6, 7, 8, 5])
+    sep_token = 5
+    mask_frac = 0.5
+    ignore_tokens = [1]
+
+    starts_and_ends, sentences_to_mask = find_sentences_to_mask(token_sequence, sep_token, mask_frac, ignore_tokens)
+
+    assert isinstance(starts_and_ends, np.ndarray)
+    assert starts_and_ends.dtype == np.int_
+    assert isinstance(sentences_to_mask, np.ndarray)
+    assert sentences_to_mask.dtype == np.int_
+
+
+def test_mask_tokens_in_sentences_basic():
+    # single sentence
+    token_sequence = np.array([1, 2, 3, 5, 8, 2, 5, 10, 15, 3, 5])
+    sentence_starts_and_ends = np.array([-1, 3, 6, 10])
+    sentences_to_mask = np.array([1])  # Mask the second sentence
+
+    expected_masked_sequence = np.array([1, 2, 3, 5, 99, 99, 5, 10, 15, 3, 5])
+    expected_target_idx = np.hstack((np.array([4, 5]), np.full(8, FILL_VAL_TARGET_IDX)))
+    expected_target_tokens = np.hstack((np.array([8, 2]), np.zeros(8)))
+
+    masked_sequence, target_idx, target_tokens = mask_tokens_in_sentences(
+        token_sequence, sentence_starts_and_ends, sentences_to_mask, MASK_ID, LEN_TARGET_ARRAY, FILL_VAL_TARGET_IDX
+    )
+
+    np.testing.assert_array_equal(masked_sequence, expected_masked_sequence)
+    np.testing.assert_array_equal(target_idx, expected_target_idx)
+    np.testing.assert_array_equal(target_tokens, expected_target_tokens)
+
+    # multiple sentences
+    sentences_to_mask = np.array([0, 2])
+
+    expected_masked_sequence = np.array([99, 99, 99, 5, 8, 2, 5, 99, 99, 99, 5])
+    expected_target_idx = np.hstack((np.array([0, 1, 2, 7, 8, 9]), np.full(4, FILL_VAL_TARGET_IDX)))
+    expected_target_tokens = np.hstack((np.array([1, 2, 3, 10, 15, 3]), np.zeros(4)))
+
+    masked_sequence, target_idx, target_tokens = mask_tokens_in_sentences(
+        token_sequence, sentence_starts_and_ends, sentences_to_mask, MASK_ID, LEN_TARGET_ARRAY, FILL_VAL_TARGET_IDX
+    )
+
+    np.testing.assert_array_equal(masked_sequence, expected_masked_sequence)
+    np.testing.assert_array_equal(target_idx, expected_target_idx)
+    np.testing.assert_array_equal(target_tokens, expected_target_tokens)
+
+
+def test_mask_tokens_in_sentences_no_masking():
+    token_sequence = np.array([1, 2, 3, 4, 5])
+    sentence_starts_and_ends = np.array([0, 5])
+    sentences_to_mask = np.array([])
+
+    masked_sequence, target_idx, target_tokens = mask_tokens_in_sentences(
+        token_sequence, sentence_starts_and_ends, sentences_to_mask, MASK_ID, LEN_TARGET_ARRAY, FILL_VAL_TARGET_IDX
+    )
+
+    np.testing.assert_array_equal(masked_sequence, token_sequence)
+    assert target_idx.size == LEN_TARGET_ARRAY
+    assert target_tokens.size == LEN_TARGET_ARRAY
+
+
+def test_mask_tokens_in_sentences_all_masking():
+    token_sequence = np.array([1, 2, 3, 4, 2, 5])  # 1 is an ignore token
+    sentence_starts_and_ends = np.array([0, 5])
+    sentences_to_mask = np.array([0])
+
+    expected_masked_sequence = np.array([1, 99, 99, 99, 99, 5])
+    expected_target_idx = np.hstack((np.array([1, 2, 3, 4]), np.full(6, FILL_VAL_TARGET_IDX)))
+    expected_target_tokens = np.hstack((np.array([2, 3, 4, 2]), np.zeros(6)))
+
+    masked_sequence, target_idx, target_tokens = mask_tokens_in_sentences(
+        token_sequence, sentence_starts_and_ends, sentences_to_mask, MASK_ID, LEN_TARGET_ARRAY, FILL_VAL_TARGET_IDX
+    )
+
+    np.testing.assert_array_equal(masked_sequence, expected_masked_sequence)
+    np.testing.assert_array_equal(target_idx, expected_target_idx)
+    np.testing.assert_array_equal(target_tokens, expected_target_tokens)
+
+
+def test_mask_tokens_in_sentences_input_validation():
+    with pytest.raises(TypeError):
+        mask_tokens_in_sentences(
+            [1, 2, 3],  # pyright: ignore[reportArgumentType]
+            np.array([0, 3]),
+            np.array([0]),
+            99,
+            10,
+            511,
+        )
+
+
+def test_mask_tokens_in_sentences_empty_input():
+    token_sequence = np.array([])
+    sentence_starts_and_ends = np.array([0])
+    sentences_to_mask = np.array([])
+
+    masked_sequence, target_idx, target_tokens = mask_tokens_in_sentences(
+        token_sequence, sentence_starts_and_ends, sentences_to_mask, MASK_ID, LEN_TARGET_ARRAY, FILL_VAL_TARGET_IDX
+    )
+
+    assert masked_sequence.size == 0
+    assert target_idx.size == LEN_TARGET_ARRAY
+    assert target_tokens.size == LEN_TARGET_ARRAY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ extend-safe-fixes = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = [
+"*/tests/*" = [
     "S101",   # Use of `assert` detected
     "PT011",  # pytest-raises-too-broad
     "ANN001", # Missing function argument type
@@ -68,6 +68,7 @@ extend-safe-fixes = [
     "D103",   # Missing function docstring
     "ANN401", # Function arguments annotated with too generic `Any` type
     "SLF001", # Private member access
+    "INP001", # Implicit namespace package in tests. see also https://github.com/astral-sh/ruff/issues/8690
 ]
 "docs/conf.py" = [
     "INP001", # Add __init__.py to implicit namespace package


### PR DESCRIPTION
- adds event masking and tests
- adds ways for masking in pipeline: "events" and "random"
- updates pyproject.toml for test directories and pre-commit hooks. necessary to make tests run

Important design decisions
- ~~always mask at least one sentence, even if the first sentence is longer than the specific masking fraction times the number of tokens in the sequence~~
- use a nested directory structure for the output of the pipeline (see below). this will require updating the structure of encoded files on the OSSC, and updating the config files for pretraining.



run tests with 
```bash
source .venv/bin/activate
python -m pytest -v -k "test_sentence_masking"
```

#### Nesting structure of pipeline output

We'll probably have different kinds of masks, both for mlm and non-mlm. We should think about a smart way to store the encoded data, and this should also map to the model names we are training. I suggest something similar to the hierarchical parquet structure we use elsewhere
- at `step5/`, we have `encoding=mlm` and `encoding=nomlm`
- inside the two, we have `masking=random`, `masking=event`, `masking=eventchunks` (in line what we discussed in today's meeting)
- inside each, we have a normal file `encoded.h5` or similar, and one with a `dryrun` flag, ie `encoded_dryrun.h5`. 



To do 
- [x] add tests for masking
- [x] add event masking option to config; pass in through main scripts
- [x] run on fake data on snellius
- [x] tidy notebook
- [x] store flag for event masking in the output file of `pipeline.py`
- [x] squash commits
